### PR TITLE
Stock and flow macro for easier definition of Stock and Flow models

### DIFF
--- a/src/Syntax.jl
+++ b/src/Syntax.jl
@@ -567,7 +567,7 @@ function flow_expr_to_symbolic_repr(flow_expression, dyvar_names)
                     throw("Unknown dynamic variable referenced " * String(expr))
                 end
             else
-                (additional_dyvars, var_name) = infix_expression_to_binops(expr)
+                (additional_dyvars, var_name) = infix_expression_to_binops(expr, gensymbase="v_" * String(flow_name))
                 dyvs = dyvar_exprs_to_symbolic_repr(additional_dyvars)
                 return (dyvs, flow_name => var_name)
             end
@@ -823,5 +823,25 @@ function set_final_binop_varname!(exprs::Vector{Tuple{Symbol,Expr}}, varname::Sy
     idx = lastindex(exprs)
     (_oldvarname, expr) = last(exprs)
     exprs[idx] = (varname, expr)
+end
+SIR_2 = @stock_and_flow begin
+    :stocks
+    S
+    I
+    R
+
+    :parameters
+    c
+    beta
+    tRec
+
+    # We can leave out dynamic variables and let them be inferred from flows entirely!
+
+    :flows
+    S => inf(S * beta * (c * (I / N))) => I
+    I => rec(I / tRec) => R
+
+    :sums
+    N = [S, I, R]
 end
 end

--- a/src/Syntax.jl
+++ b/src/Syntax.jl
@@ -3,13 +3,22 @@ module Syntax
 using StockFlow
 using MLStyle
 
-test_infix_expr = :(a + b * c - d - e - h * j + k + l + m * n * o * p / q / r + s - t - u * v - w / x * y + z)
+test_infix_expr = quote
+    a + b * c - d - e - f(g) + h(j, k) + l + m * n * o * p / q / r + s - t - u * v - w / x * y + z
+end
+Base.remove_linenums!(test_infix_expr)
 function infix_expression_to_binops(expression)
     syms = []
     function loop(e)
         @match e begin
             ::Symbol => begin
                 e
+            end
+            Expr(:call, f, a) => begin
+                asym = loop(a)
+                varname = gensym("")
+                push!(syms, :($varname = $f($asym)))
+                varname
             end
             Expr(:call, f, a, b) => begin
                 asym = loop(a)

--- a/src/Syntax.jl
+++ b/src/Syntax.jl
@@ -3,11 +3,6 @@ module Syntax
 using StockFlow
 using MLStyle
 
-test_infix_expr = quote
-    a + b * c - d - e - f(g) + h(j, k) + l + m * n * o * p / q / r + s - t - u * v - w / x * y + z
-end
-Base.remove_linenums!(test_infix_expr)
-
 function replace_in_last(exprs, symtoreplace, targetsym)
     idx = lastindex(exprs)
     expr = last(exprs)
@@ -28,9 +23,8 @@ function infix_expression_to_binops(expression, finalsym=nothing)
     exprs = []
     function loop(e)
         @match e begin
-            ::Symbol => begin
+            ::Symbol =>
                 e
-            end
             Expr(:call, f, a) => begin
                 asym = loop(a)
                 varname = gensym("")
@@ -59,7 +53,7 @@ function infix_expression_to_binops(expression, finalsym=nothing)
                 lastsym
             end
             Expr(en, _, _, _) || Expr(en, _, _) => begin
-                throw("Unhandled expression " * String(en))
+                throw("Unhandled expression cannot be converted into form f(a, b) " * String(en))
             end
         end
     end
@@ -71,7 +65,28 @@ function infix_expression_to_binops(expression, finalsym=nothing)
     exprs, lastsym
 end
 
-struct StockAndFlowSyntax
+function extract_flow_name_and_equation(flow)
+    @match flow begin
+        :($flow_name($expr)) =>
+            (flow_name, expr)
+        Expr(en, _, _, _) || Expr(en, _, _) =>
+            throw("Unhandled expression in flow definition " * String(en))
+    end
+end
+
+function parse_flow(flow_definition)
+    @match flow_definition begin
+        :(TODO => $flow => $stock_out) || :(☁ => $flow => $stock_out) =>
+            (:F_NONE, flow, stock_out)
+        :($stock_in => $flow => TODO) || :($stock_in => $flow => ☁) =>
+            (stock_in, flow, :F_NONE)
+        :($stock_in => $flow => $stock_out) =>
+            (stock_in, flow, stock_out)
+        Expr(en, _, _, _) || Expr(en, _, _) =>
+            throw("Unhandled expression in flow definition " * String(en))
+    end
+end
+struct StockAndFlowArguments
     stocks::Array{Tuple{Symbol,Tuple{Symbol,Symbol,Symbol}}}
     params::Array{Symbol}
     dyvars::Array{Tuple{Symbol,Tuple{Symbol,Symbol,Symbol}}}
@@ -79,10 +94,16 @@ struct StockAndFlowSyntax
     sums::Array{Symbol}
 end
 
+struct StockAndFlowSyntax
+    stocks::Array{Symbol}
+    params::Array{Symbol}
+    dyvars::Array{Tuple{Symbol,Expr}}
+    flows::Array{Tuple{Symbol,Expr,Symbol}}
+    sums::Array{Tuple{Symbol,Expr}}
+end
+
 function stocks_phase(stocks, stock)
-    stock_name = stock.args[1]
-    stock_syms = Tuple(Symbol(x) for x in stock.args[2].args)
-    push!(stocks, (stock_name, stock_syms))
+    push!(stocks, stock)
 end
 
 function params_phase(params, param)
@@ -90,68 +111,116 @@ function params_phase(params, param)
 end
 
 function dyvars_phase(dyvars, dyvar)
-    dyvar_name = dyvar.args[1]
-    dyvar_def = Tuple(d for d in dyvar.args[2].args)
-    push!(dyvars, (dyvar_name, dyvar_def))
+    @match dyvar begin
+        :($dyvar_name = $dyvar_def) =>
+            push!(dyvars, (dyvar_name, dyvar_def))
+        Expr(c, _, _) || Expr(c, _, _, _) =>
+            throw("Unhandled expression in dynamic variable definition " * String(c))
+    end
 end
 
 function flows_phase(flows, flow)
-    push!(flows, (flow.args[2] => flow.args[3]))
+    push!(flows, parse_flow(flow))
 end
 
-function sums_phase(sums, sym)
-    push!(sums, sym)
+function sums_phase(sums, sum)
+    @match sum begin
+        :($sum_name = $equation) =>
+            push!(sums, (sum_name, equation))
+        Expr(c, _, _) || Expr(c, _, _, _) =>
+            throw("Unhandled expression in sum defintion " * String(c))
+    end
 end
 
 function collect_elements(statements)
-    Base.remove_linenums!(statements)
-    stocks::Array{Tuple{Symbol,Tuple{Symbol,Symbol,Symbol}}} = []
+    stocks::Array{Symbol} = []
     params::Array{Symbol} = []
-    dyvars::Array{Tuple{Symbol,Tuple{Symbol,Symbol,Symbol}}} = []
-    flows::Array{Pair{Symbol,Symbol}} = []
-    sums::Array{Symbol} = []
+    dyvars::Array{Tuple{Symbol,Expr}} = []
+    flows::Array{Tuple{Symbol,Expr,Symbol}} = []
+    sums::Array{Tuple{Symbol,Expr}} = []
     current_phase = (_, _) -> ()
     for statement in statements
-        if typeof(statement) <: QuoteNode
-            kw = statement.value
-            if kw == :stocks
+        @match statement begin
+            QuoteNode(:stocks) => begin
                 current_phase = s -> stocks_phase(stocks, s)
-            elseif kw == :parameters
-                current_phase = p -> params_phase(params, p)
-            elseif kw == :dynamic_variables
-                current_phase = d -> dyvars_phase(dyvars, d)
-            elseif kw == :flows
-                current_phase = f -> flows_phase(flows, f)
-            elseif kw == :sums
-                current_phase = s -> sums_phase(sums, s)
-            else
-                throw("Unknown keyword for Stock and Flow syntax: " * String(kw))
             end
-        else
-            current_phase(statement)
+            QuoteNode(:parameters) => begin
+                current_phase = p -> params_phase(params, p)
+            end
+            QuoteNode(:dynamic_variables) => begin
+                current_phase = d -> dyvars_phase(dyvars, d)
+            end
+            QuoteNode(:flows) => begin
+                current_phase = f -> flows_phase(flows, f)
+            end
+            QuoteNode(:sums) => begin
+                current_phase = s -> sums_phase(sums, s)
+            end
+            QuoteNode(kw) =>
+                throw("Unknown block type for Stock and Flow syntax: " * String(kw))
+            _ =>
+                current_phase(statement)
         end
     end
 
-    return StockAndFlowSyntax(stocks, params, dyvars, flows, sums)
+    s = StockAndFlowSyntax(stocks, params, dyvars, flows, sums)
+    println(s)
+    return s
+end
+
+function assemble_stock_and_flow_f(syntax_elements)
 end
 
 macro stock_and_flow(block)
     Base.remove_linenums!(block)
     syntax = collect_elements(block.args)
-    stocks = Tuple(stock_name => outputs for (stock_name, outputs) in syntax.stocks)
-    params = syntax.params
-    dyvars = Tuple(dyvar_name => ((dyvar_param1, dyvar_param2) => dyvar_func) for (dyvar_name, (dyvar_func, dyvar_param1, dyvar_param2)) in syntax.dyvars)
-    flows = Tuple(f for f in syntax.flows)
-    sums = syntax.sums
-    return StockAndFlowF(stocks, params, dyvars, flows, sums)
+    #    stocks = Tuple(stock_name => outputs for (stock_name, outputs) in syntax.stocks)
+    #    params = syntax.params
+    #    dyvars = Tuple(dyvar_name => ((dyvar_param1, dyvar_param2) => dyvar_func) for (dyvar_name, (dyvar_func, dyvar_param1, dyvar_param2)) in syntax.dyvars)
+    #    flows = Tuple(f for f in syntax.flows)
+    #    sums = syntax.sums
+    #    return StockAndFlowF(stocks, params, dyvars, flows, sums)
+end
+
+test_infix_expr = :(a + b * c - d - e - f(g) + h(j, k) + l + m * n * o * p / q / r + s - t - u * v - w / x * y + z)
+Base.remove_linenums!(test_infix_expr)
+
+SIR = @stock_and_flow begin
+    :stocks
+    S
+    I
+    R
+
+    :parameters
+    c
+    beta
+    tRec
+    omega
+    alpha
+
+    :dynamic_variables
+    v_prevalence = I / N
+    v_forceOfInfection = c * v_prevalence * beta
+
+    :flows
+    S => inf(S * v_forceOfInfection) => I
+    ☁ => births(totalPopulation * alpha) => S
+    S => deathsS(S * omega) => ☁
+    I => rec(I / tRec) => R
+    I => deathsI(I * omega) => ☁
+    R => deathsR(R * omega) => ☁
+
+
+    :sums
+    totalPopulation = (S, I, R)
 end
 
 # New syntax
-SIR = @stock_and_flow begin
+SIR_2 = @stock_and_flow begin
     :stocks
-    S = (F_NONE, inf, N)
-    I = (inf, rec, N)
-    R = (rec, F_NONE, N)
+    S
+    I
+    R
 
     :parameters
     c
@@ -162,15 +231,13 @@ SIR = @stock_and_flow begin
     v_prevalence = I / N
     v_meanInfectiousContactsPerS = c * v_prevalence
     v_perSIncidenceRate = beta * v_meanInfectiousContactsPerS
-    v_newInfections = S * v_perSIncidenceRate
-    v_newRecovery = I / tRec
 
     :flows
-    inf => v_newInfections
-    rec => v_newRecovery
+    S => inf(S * v_perSIncidenceRate) => I
+    I => rec(I / tRec) => R
 
     :sums
-    N
+    N = [S, I, R]
 end
 
 # Current:
@@ -180,6 +247,5 @@ SIR_curr = StockAndFlowF((:S => (:F_NONE, :inf, :N), :I => (:inf, :rec, :N), :R 
         :v_newInfections => ((:S, :v_perSIncidenceRate) => :*), :v_newRecovery => ((:I, :tRec) => :/)),# dynamical variables
     (:inf => :v_newInfections, :rec => :v_newRecovery),# flows
     (:N))# sum dynamical variables
-
 
 end

--- a/src/Syntax.jl
+++ b/src/Syntax.jl
@@ -134,7 +134,7 @@ Compiles stock and flow syntax of the line-based block form
     symbol_r => flow_name_1(dyvar_k) => symbol_q
     symbol_z => flow_name_2(dyvar_g * param_v) => symbol_p
     ☁       => flow_name_3(symbol_c + dyvar_b) => symbol_r
-    symbol_j => flow_name_4(param_l + symbol_m) => TODO
+    symbol_j => flow_name_4(param_l + symbol_m) => CLOUD
     ...
     symbol_y => flow_name_n(dyvar_f) => ☁
 ```
@@ -336,7 +336,7 @@ function parse_dyvar!(dyvars::Vector{Tuple{Symbol,Expr}}, dyvar::Expr)
 end
 
 """
-    parse_flow_io(flow_definition :: Expr)
+    parse_flow(flow_definition :: Expr)
 
 Given a flow definition of the form `SYMBOL => flow_name(flow_equation) => SYMBOL`,
 return a 3-tuple of its constituent parts: the start symbol, the end symbol,
@@ -345,7 +345,7 @@ and the flow equations's definition as an expression.
 ### Input
 - `flow_definition` -- A flow definition of the form
                        `SYMBOL => flow_name(flow_equation) => SYMBOL`,
-                       where SYMBOL can be an arbitrary name or special cases of ☁ or TODO,
+                       where SYMBOL can be an arbitrary name or special cases of ☁ or CLOUD,
                        which corresponds to a flow from nowhere.
 
 ### Output
@@ -354,17 +354,27 @@ may be :F_NONE for a flow from nowhere) and the flow equation as a julia express
 
 ### Examples
 ```julia-repl
-julia> Syntax.parse_flow_io(:(TODO => birthRate(a * b * c) => S))
+julia> Syntax.parse_flow_io(:(CLOUD => birthRate(a * b * c) => S))
 (:F_NONE, :(birthRate(a * b * c)), :S)
 ```
 """
 function parse_flow(flow_definition::Expr)
     @match flow_definition begin
-        :(TODO => $flow => $stock_out) || :(☁ => $flow => $stock_out) =>
+        :(CLOUD => $flow => $stock_out) || :(☁ => $flow => $stock_out) =>
             (:F_NONE, flow, stock_out)
-        :($stock_in => $flow => TODO) || :($stock_in => $flow => ☁) =>
+        :($stock_in => $flow => CLOUD) || :($stock_in => $flow => ☁) =>
             (stock_in, flow, :F_NONE)
-        :($stock_in => $flow => $stock_out) => (stock_in, flow, stock_out)
+        :($stock_in => $flow => $stock_out) => begin
+            stock_in_str = String(stock_in)
+            stock_out_str = String(stock_out)
+            if lowercase(stock_in_str) == "cloud"
+                stock_in = :F_NONE
+            end
+            if lowercase(stock_out_str) == "cloud"
+                stock_out = :F_NONE
+            end
+            (stock_in, flow, stock_out)
+        end
         Expr(en, _, _, _) || Expr(en, _, _) =>
             throw("Unhandled expression in flow definition " * String(en))
     end

--- a/src/Syntax.jl
+++ b/src/Syntax.jl
@@ -824,24 +824,4 @@ function set_final_binop_varname!(exprs::Vector{Tuple{Symbol,Expr}}, varname::Sy
     (_oldvarname, expr) = last(exprs)
     exprs[idx] = (varname, expr)
 end
-SIR_2 = @stock_and_flow begin
-    :stocks
-    S
-    I
-    R
-
-    :parameters
-    c
-    beta
-    tRec
-
-    # We can leave out dynamic variables and let them be inferred from flows entirely!
-
-    :flows
-    S => inf(S * beta * (c * (I / N))) => I
-    I => rec(I / tRec) => R
-
-    :sums
-    N = [S, I, R]
-end
 end

--- a/src/Syntax.jl
+++ b/src/Syntax.jl
@@ -1,0 +1,116 @@
+module Syntax
+
+using StockFlow
+
+struct StockAndFlowSyntax
+    stocks::Array{Tuple{Symbol,Tuple{Symbol,Symbol,Symbol}}}
+    params::Array{Symbol}
+    dyvars::Array{Tuple{Symbol,Tuple{Symbol,Symbol,Symbol}}}
+    flows::Array{Pair{Symbol,Symbol}}
+    sums::Array{Symbol}
+end
+
+function stocks_phase(stocks, stock)
+    stock_name = stock.args[1]
+    stock_syms = Tuple(Symbol(x) for x in stock.args[2].args)
+    push!(stocks, (stock_name, stock_syms))
+end
+
+function params_phase(params, param)
+    push!(params, param)
+end
+
+function dyvars_phase(dyvars, dyvar)
+    dyvar_name = dyvar.args[1]
+    dyvar_def = Tuple(d for d in dyvar.args[2].args)
+    push!(dyvars, (dyvar_name, dyvar_def))
+end
+
+function flows_phase(flows, flow)
+    push!(flows, (flow.args[2] => flow.args[3]))
+end
+
+function sums_phase(sums, sym)
+    push!(sums, sym)
+end
+
+function collect_elements(statements)
+    Base.remove_linenums!(statements)
+    stocks::Array{Tuple{Symbol,Tuple{Symbol,Symbol,Symbol}}} = []
+    params::Array{Symbol} = []
+    dyvars::Array{Tuple{Symbol,Tuple{Symbol,Symbol,Symbol}}} = []
+    flows::Array{Pair{Symbol,Symbol}} = []
+    sums::Array{Symbol} = []
+    current_phase = (_, _) -> ()
+    for statement in statements
+        if typeof(statement) <: QuoteNode
+            kw = statement.value
+            if kw == :stocks
+                current_phase = s -> stocks_phase(stocks, s)
+            elseif kw == :parameters
+                current_phase = p -> params_phase(params, p)
+            elseif kw == :dynamic_variables
+                current_phase = d -> dyvars_phase(dyvars, d)
+            elseif kw == :flows
+                current_phase = f -> flows_phase(flows, f)
+            elseif kw == :sums
+                current_phase = s -> sums_phase(sums, s)
+            else
+                throw("Unknown keyword for Stock and Flow syntax: " * String(kw))
+            end
+        else
+            current_phase(statement)
+        end
+    end
+
+    return StockAndFlowSyntax(stocks, params, dyvars, flows, sums)
+end
+
+macro stock_and_flow(block)
+    Base.remove_linenums!(block)
+    syntax = collect_elements(block.args)
+    stocks = Tuple(stock_name => outputs for (stock_name, outputs) in syntax.stocks)
+    params = syntax.params
+    dyvars = Tuple(dyvar_name => ((dyvar_param1, dyvar_param2) => dyvar_func) for (dyvar_name, (dyvar_func, dyvar_param1, dyvar_param2)) in syntax.dyvars)
+    flows  = Tuple(f for f in syntax.flows)
+    sums   = syntax.sums
+    return StockAndFlowF(stocks, params, dyvars, flows, sums)
+end
+
+# New syntax
+SIR = @stock_and_flow begin
+    :stocks
+    S = (F_NONE, inf, N)
+    I = (inf, rec, N)
+    R = (rec, F_NONE, N)
+
+    :parameters
+    c
+    beta
+    tRec
+
+    :dynamic_variables
+    v_prevalence = I / N
+    v_meanInfectiousContactsPerS = c * v_prevalence
+    v_perSIncidenceRate = beta * v_meanInfectiousContactsPerS
+    v_newInfections = S * v_perSIncidenceRate
+    v_newRecovery = I / tRec
+
+    :flows
+    inf => v_newInfections
+    rec => v_newRecovery
+
+    :sums
+    N
+end
+
+# Current:
+SIR_curr = StockAndFlowF((:S => (:F_NONE, :inf, :N), :I => (:inf, :rec, :N), :R => (:rec, :F_NONE, :N)),# stocks
+    (:c, :beta, :tRec),# parameters
+    (:v_prevalence => ((:I, :N) => :/), :v_meanInfectiousContactsPerS => ((:c, :v_prevalence) => :*), :v_perSIncidenceRate => ((:beta, :v_meanInfectiousContactsPerS) => :*),
+        :v_newInfections => ((:S, :v_perSIncidenceRate) => :*), :v_newRecovery => ((:I, :tRec) => :/)),# dynamical variables
+    (:inf => :v_newInfections, :rec => :v_newRecovery),# flows
+    (:N))# sum dynamical variables
+
+
+end

--- a/src/Syntax.jl
+++ b/src/Syntax.jl
@@ -3,39 +3,48 @@ module Syntax
 using StockFlow
 using MLStyle
 
-function replace_in_last(exprs, symtoreplace, targetsym)
+
+struct StockAndFlowArguments
+    stocks::Vector{Pair{Symbol,Tuple{Union{Symbol,Vector{Symbol}},Union{Symbol,Vector{Symbol}},Union{Symbol,Vector{Symbol}}}}}
+    params::Vector{Symbol}
+    dyvars::Vector{Pair{Symbol,Pair{Tuple{Symbol,Symbol},Symbol}}}
+    flows::Vector{Pair{Symbol,Symbol}}
+    sums::Vector{Symbol}
+end
+
+struct StockAndFlowSyntax
+    stocks::Vector{Symbol}
+    params::Vector{Symbol}
+    dyvars::Vector{Tuple{Symbol,Expr}}
+    flows::Vector{Tuple{Symbol,Expr,Symbol}}
+    sums::Vector{Tuple{Symbol,Vector{Symbol}}}
+end
+
+function set_final_binop_varname!(exprs::Vector{Tuple{Symbol,Expr}}, symtoreplace::Symbol, targetsym::Symbol)
     idx = lastindex(exprs)
-    expr = last(exprs)
-    try
-        updatedexpr = @match expr begin
-            Expr(:(=), sym, expr) => begin
-                if sym == symtoreplace
-                    :($targetsym = $expr)
-                end
-            end
-        end
-        exprs[idx] = updatedexpr
-    catch _
+    (s, expr) = last(exprs)
+    if s == symtoreplace
+      exprs[idx] = (targetsym, expr)
     end
 end
 
-function infix_expression_to_binops(expression, finalsym=nothing)
-    exprs = []
+function is_binop(e::Expr)
+    @match e begin
+        Expr(:call, f, a, b) => true
+        _ => false
+    end
+end
+function infix_expression_to_binops(expression::Expr, finalsym=nothing::Union{Nothing,Symbol})
+    exprs::Vector{Tuple{Symbol,Expr}} = []
     function loop(e)
         @match e begin
             ::Symbol =>
                 e
-            Expr(:call, f, a) => begin
-                asym = loop(a)
-                varname = gensym("")
-                push!(exprs, :($varname = $f($asym)))
-                varname
-            end
             Expr(:call, f, a, b) => begin
                 asym = loop(a)
                 bsym = loop(b)
                 varname = gensym("")
-                push!(exprs, :($varname = $f($asym, $bsym)))
+                push!(exprs, (varname, :($f($asym, $bsym))))
                 varname
             end
             Expr(:call, f, args...) => begin
@@ -43,11 +52,11 @@ function infix_expression_to_binops(expression, finalsym=nothing)
                 lastsym = gensym("")
                 a = popfirst!(argsyms)
                 b = popfirst!(argsyms)
-                symexpr = :($lastsym = $f($a, $b))
-                push!(exprs, symexpr)
+                symexpr = :($f($a, $b))
+                push!(exprs, (lastsym, symexpr))
                 for argsym in argsyms
                     currsym = gensym("")
-                    push!(exprs, :($currsym = $f($lastsym, $argsym)))
+                    push!(exprs, (currsym, :($f($lastsym, $argsym))))
                     lastsym = currsym
                 end
                 lastsym
@@ -59,22 +68,24 @@ function infix_expression_to_binops(expression, finalsym=nothing)
     end
     lastsym = loop(expression)
     if finalsym !== nothing
-        replace_in_last(exprs, lastsym, finalsym)
+        set_final_binop_varname!(exprs, lastsym, finalsym)
         lastsym = finalsym
     end
     exprs, lastsym
 end
 
-function extract_flow_name_and_equation(flow)
+function extract_flow_name_and_equation(flow::Expr)
     @match flow begin
         :($flow_name($expr)) =>
             (flow_name, expr)
+        :($flow_name($expr, name=$_)) =>
+            (flow_name, expr)
         Expr(en, _, _, _) || Expr(en, _, _) =>
-            throw("Unhandled expression in flow definition " * String(en))
+            throw("Unhandled expression in flow name definition " * String(en))
     end
 end
 
-function parse_flow(flow_definition)
+function parse_flow_io(flow_definition::Expr)
     @match flow_definition begin
         :(TODO => $flow => $stock_out) || :(☁ => $flow => $stock_out) =>
             (:F_NONE, flow, stock_out)
@@ -86,31 +97,16 @@ function parse_flow(flow_definition)
             throw("Unhandled expression in flow definition " * String(en))
     end
 end
-struct StockAndFlowArguments
-    stocks::Array{Tuple{Symbol,Tuple{Symbol,Symbol,Symbol}}}
-    params::Array{Symbol}
-    dyvars::Array{Tuple{Symbol,Tuple{Symbol,Symbol,Symbol}}}
-    flows::Array{Pair{Symbol,Symbol}}
-    sums::Array{Symbol}
-end
 
-struct StockAndFlowSyntax
-    stocks::Array{Symbol}
-    params::Array{Symbol}
-    dyvars::Array{Tuple{Symbol,Expr}}
-    flows::Array{Tuple{Symbol,Expr,Symbol}}
-    sums::Array{Tuple{Symbol,Expr}}
-end
-
-function stocks_phase(stocks, stock)
+function parse_stock!(stocks::Vector{Symbol}, stock::Symbol)
     push!(stocks, stock)
 end
 
-function params_phase(params, param)
+function parse_param!(params::Vector{Symbol}, param::Symbol)
     push!(params, param)
 end
 
-function dyvars_phase(dyvars, dyvar)
+function parse_dyvar!(dyvars::Vector{Tuple{Symbol,Expr}}, dyvar::Expr)
     @match dyvar begin
         :($dyvar_name = $dyvar_def) =>
             push!(dyvars, (dyvar_name, dyvar_def))
@@ -119,42 +115,42 @@ function dyvars_phase(dyvars, dyvar)
     end
 end
 
-function flows_phase(flows, flow)
-    push!(flows, parse_flow(flow))
+function parse_flow!(flows::Vector{Tuple{Symbol,Expr,Symbol}}, flow::Expr)
+    push!(flows, parse_flow_io(flow))
 end
 
-function sums_phase(sums, sum)
+function parse_sum!(sums::Vector{Tuple{Symbol,Vector{Symbol}}}, sum::Expr)
     @match sum begin
         :($sum_name = $equation) =>
-            push!(sums, (sum_name, equation))
+            push!(sums, (sum_name, equation.args))
         Expr(c, _, _) || Expr(c, _, _, _) =>
             throw("Unhandled expression in sum defintion " * String(c))
     end
 end
 
-function collect_elements(statements)
-    stocks::Array{Symbol} = []
-    params::Array{Symbol} = []
-    dyvars::Array{Tuple{Symbol,Expr}} = []
-    flows::Array{Tuple{Symbol,Expr,Symbol}} = []
-    sums::Array{Tuple{Symbol,Expr}} = []
+function parse_stock_and_flow_syntax(statements::Vector{Any})
+    stocks::Vector{Symbol} = []
+    params::Vector{Symbol} = []
+    dyvars::Vector{Tuple{Symbol,Expr}} = []
+    flows::Vector{Tuple{Symbol,Expr,Symbol}} = []
+    sums::Vector{Tuple{Symbol,Vector{Symbol}}} = []
     current_phase = (_, _) -> ()
     for statement in statements
         @match statement begin
             QuoteNode(:stocks) => begin
-                current_phase = s -> stocks_phase(stocks, s)
+                current_phase = s -> parse_stock!(stocks, s)
             end
             QuoteNode(:parameters) => begin
-                current_phase = p -> params_phase(params, p)
+                current_phase = p -> parse_param!(params, p)
             end
             QuoteNode(:dynamic_variables) => begin
-                current_phase = d -> dyvars_phase(dyvars, d)
+                current_phase = d -> parse_dyvar!(dyvars, d)
             end
             QuoteNode(:flows) => begin
-                current_phase = f -> flows_phase(flows, f)
+                current_phase = f -> parse_flow!(flows, f)
             end
             QuoteNode(:sums) => begin
-                current_phase = s -> sums_phase(sums, s)
+                current_phase = s -> parse_sum!(sums, s)
             end
             QuoteNode(kw) =>
                 throw("Unknown block type for Stock and Flow syntax: " * String(kw))
@@ -164,59 +160,121 @@ function collect_elements(statements)
     end
 
     s = StockAndFlowSyntax(stocks, params, dyvars, flows, sums)
-    println(s)
     return s
 end
 
-function assemble_stock_and_flow_f(syntax_elements)
+
+function fnone_or_tuple(arrows::Vector{Symbol})
+    if isempty(arrows)
+        :F_NONE
+    elseif length(arrows) == 1
+        arrows[1]
+    else
+        arrows
+    end
+end
+
+function assemble_stock_defintions(stocks::Vector{Symbol}, flows::Vector{Tuple{Symbol,Expr,Symbol}}, sum_variables::Vector{Tuple{Symbol,Vector{Symbol}}})
+    formatted_stocks = []
+    for stock in stocks
+        input_arrows::Vector{Symbol} = []
+        output_arrows::Vector{Symbol} = []
+        sum_arrows::Vector{Symbol} = []
+        for (start_object, flow, end_object) in flows
+            (flow_name, _) = extract_flow_name_and_equation(flow)
+            if start_object == stock
+                push!(output_arrows, flow_name)
+            end
+            if end_object == stock
+                push!(input_arrows, flow_name)
+            end
+        end
+        for (sum_variable_name, inputs) in sum_variables
+            if stock in inputs
+                push!(sum_arrows, sum_variable_name)
+            end
+        end
+        push!(formatted_stocks, (stock => (fnone_or_tuple(input_arrows), fnone_or_tuple(output_arrows), fnone_or_tuple(sum_arrows))))
+    end
+    return formatted_stocks
+end
+
+function unfold_dyvars_to_binops(dyvars::Vector{Tuple{Symbol,Expr}})
+    syms::Vector{Pair{Symbol,Pair{Tuple{Symbol,Symbol},Symbol}}} = []
+    for (dyvar_name, dyvar_definition) in dyvars
+        if is_binop(dyvar_definition)
+            @match dyvar_definition begin
+                Expr(:call, op, a, b) => begin
+                    push!(syms, (dyvar_name => ((a, b) => op)))
+                end
+                Expr(c, _, _) || Expr(c, _, _, _) =>
+                    throw("Unhandled expression in dynamic variable definition " * String(c))
+            end
+        else
+            (binops, _) = infix_expression_to_binops(dyvar_definition, dyvar_name)
+            binops_syms = unfold_dyvars_to_binops(binops)
+            syms = vcat(syms, binops_syms)
+        end
+    end
+    return syms
+end
+
+function disassemble_flow_equation(flow_expression, dyvars)
+    @match flow_expression begin
+        :($flow_name($expr)) => begin
+          if typeof(expr) <: Symbol
+              # TODO: search for the 'op' in dyvars to see if it's defined as a dynamic variable.
+              #       if so, we can assemble it into 'flow_name => dyvar_name' in stock and flow
+              #       Elsewise, err.
+              return ([], flow_name => expr)
+          else
+              (additional_dyvars, var_name) = infix_expression_to_binops(expr)
+              return (additional_dyvars, flow_name => var_name)
+          end
+        end
+        :($flow_name($expr, name=$sym)) => begin
+            (additional_dyvars, var_name) = infix_expression_to_binops(expr, sym)
+            return (additional_dyvars, flow_name => sym)
+        end
+        Expr(c, _, _) || Expr(c, _, _, _) => begin
+            throw("Unhandled expression in flow equation definition " * String(c))
+        end
+    end
+end
+
+function assemble_flows(flows::Vector{Tuple{Symbol,Expr,Symbol}}, dyvars)
+    flow_definitions = []
+    updated_dyvars = []
+    for (start_object, flow, end_object) in flows
+        (flow_name, equation) = extract_flow_name_and_equation(flow)
+        (additional_dyvars, var_name) = infix_expression_to_binops(equation)
+        push!(flow_definitions, (flow_name => var_name))
+        updated_dyvars = vcat(updated_dyvars, unfold_dyvars_to_binops(additional_dyvars))
+    end
+    return (flow_definitions, updated_dyvars)
+end
+
+function assemble_stock_and_flow_f(syntax_elements::StockAndFlowSyntax)
+    stocks = assemble_stock_defintions(syntax_elements.stocks, syntax_elements.flows, syntax_elements.sums)
+    params = syntax_elements.params
+    binop_dyvars = unfold_dyvars_to_binops(syntax_elements.dyvars)
+    (flows, flow_dyvars) = assemble_flows(syntax_elements.flows, binop_dyvars)
+    all_dyvars = vcat(binop_dyvars, flow_dyvars)
+    sums = [s for (s, _) in syntax_elements.sums]
+    return StockAndFlowArguments(stocks, params, all_dyvars, flows, sums)
 end
 
 macro stock_and_flow(block)
     Base.remove_linenums!(block)
-    syntax = collect_elements(block.args)
-    #    stocks = Tuple(stock_name => outputs for (stock_name, outputs) in syntax.stocks)
-    #    params = syntax.params
-    #    dyvars = Tuple(dyvar_name => ((dyvar_param1, dyvar_param2) => dyvar_func) for (dyvar_name, (dyvar_func, dyvar_param1, dyvar_param2)) in syntax.dyvars)
-    #    flows = Tuple(f for f in syntax.flows)
-    #    sums = syntax.sums
-    #    return StockAndFlowF(stocks, params, dyvars, flows, sums)
+    syntax = parse_stock_and_flow_syntax(block.args)
+    args = assemble_stock_and_flow_f(syntax)
+    return StockAndFlowF(args.stocks, args.params, args.dyvars, args.flows, args.sums)
 end
 
 test_infix_expr = :(a + b * c - d - e - f(g) + h(j, k) + l + m * n * o * p / q / r + s - t - u * v - w / x * y + z)
 Base.remove_linenums!(test_infix_expr)
-
-SIR = @stock_and_flow begin
-    :stocks
-    S
-    I
-    R
-
-    :parameters
-    c
-    beta
-    tRec
-    omega
-    alpha
-
-    :dynamic_variables
-    v_prevalence = I / N
-    v_forceOfInfection = c * v_prevalence * beta
-
-    :flows
-    S => inf(S * v_forceOfInfection) => I
-    ☁ => births(totalPopulation * alpha) => S
-    S => deathsS(S * omega) => ☁
-    I => rec(I / tRec) => R
-    I => deathsI(I * omega) => ☁
-    R => deathsR(R * omega) => ☁
-
-
-    :sums
-    totalPopulation = (S, I, R)
-end
-
 # New syntax
-SIR_2 = @stock_and_flow begin
+SIR = @stock_and_flow begin
     :stocks
     S
     I
@@ -233,8 +291,8 @@ SIR_2 = @stock_and_flow begin
     v_perSIncidenceRate = beta * v_meanInfectiousContactsPerS
 
     :flows
-    S => inf(S * v_perSIncidenceRate) => I
-    I => rec(I / tRec) => R
+    S => inf(S * v_perSIncidenceRate, name=v_newInfections) => I
+    I => rec(I / tRec, name=v_newRecovery) => R
 
     :sums
     N = [S, I, R]
@@ -247,5 +305,37 @@ SIR_curr = StockAndFlowF((:S => (:F_NONE, :inf, :N), :I => (:inf, :rec, :N), :R 
         :v_newInfections => ((:S, :v_perSIncidenceRate) => :*), :v_newRecovery => ((:I, :tRec) => :/)),# dynamical variables
     (:inf => :v_newInfections, :rec => :v_newRecovery),# flows
     (:N))# sum dynamical variables
+
+
+# TODO
+# SIR = @stock_and_flow begin
+#     :stocks
+#     S
+#     I
+#     R
+#
+#     :parameters
+#     c
+#     beta
+#     tRec
+#     omega
+#     alpha
+#
+#     :dynamic_variables
+#     v_prevalence = I / N
+#     v_forceOfInfection = c * v_prevalence * beta
+#
+#     :flows
+#     S => inf(S * v_forceOfInfection) => I
+#     ☁ => births(totalPopulation * alpha) => S
+#     S => deathsS(S * omega) => ☁
+#     I => rec(I / tRec) => R
+#     I => deathsI(I * omega) => ☁
+#     R => deathsR(R * omega) => ☁
+#
+#
+#     :sums
+#     totalPopulation = (S, I, R)
+# end
 
 end

--- a/src/Syntax.jl
+++ b/src/Syntax.jl
@@ -4,12 +4,22 @@ using StockFlow
 using MLStyle
 
 """
-Contains the five parameters required to instantiate a StockAndFlowF data type, representing a Stock and Flow model.
+Contains the five parameters required to instantiate a StockAndFlowF data type,
+representing a Stock and Flow model.
 
 This can be used to directly instantiate StockAndFlowF.
 """
 struct StockAndFlowArguments
-    stocks::Vector{Pair{Symbol,Tuple{Union{Symbol,Vector{Symbol}},Union{Symbol,Vector{Symbol}},Union{Symbol,Vector{Symbol}}}}}
+    stocks::Vector{
+        Pair{
+            Symbol,
+            Tuple{
+                Union{Symbol,Vector{Symbol}},
+                Union{Symbol,Vector{Symbol}},
+                Union{Symbol,Vector{Symbol}},
+            },
+        },
+    }
     params::Vector{Symbol}
     dyvars::Vector{Pair{Symbol,Pair{Tuple{Symbol,Symbol},Symbol}}}
     flows::Vector{Pair{Symbol,Symbol}}
@@ -17,18 +27,21 @@ struct StockAndFlowArguments
 end
 
 """
-    StockAndFlowSyntax
+    StockAndFlowBlock
 
 Contains the elements that make up the Stock and Flow block syntax.
 
 ### Fields
 - `stocks` -- Each stock is defined by a single valid Julia variable name on a line.
 - `params` -- Each parameter is defined by a single valid Julia variable name on a line.
-- `dyvars` -- Each dynamic variable is defined by a valid Julia assignment statement of the form `dyvar = expr`
-- `flows`  -- Each flow is defined by a valid Julia pair expression of the form `variable_name => flow_name(flow_expression) => variable_name`
-- `sums`   -- Each sum is defined by a valid Julia assignment statement of the form `sum_name = [a, b, c, ...]`
+- `dyvars` -- Each dynamic variable is defined by a valid Julia assignment statement of the
+              form `dyvar = expr`
+- `flows`  -- Each flow is defined by a valid Julia pair expression of the form
+              `variable_name => flow_name(flow_expression) => variable_name`
+- `sums`   -- Each sum is defined by a valid Julia assignment statement of the form
+              `sum_name = [a, b, c, ...]`
 """
-struct StockAndFlowSyntax
+struct StockAndFlowBlock
     stocks::Vector{Symbol}
     params::Vector{Symbol}
     dyvars::Vector{Tuple{Symbol,Expr}}
@@ -39,19 +52,26 @@ end
 """
     set_finaL_binop_varname!(exprs::Vector{Tuple{Symbol, Expr}}, targetsym::Symbol)
 
-Given an expression that is in the form of a series of binary operations (e.g. from infix_expression_to_binops), replace the final generated symbol with a given one.
+Given an expression that is in the form of a series of binary operations
+(e.g. from infix_expression_to_binops), replace the final generated symbol with a given one.
 
 ### Input
-- `exprs` -- A vector of tuples of variable name symbols and their corresponding expression definitions.
+- `exprs` -- A vector of tuples of variable name symbols and their corresponding expression
+             definitions.
 - `varname` -- The final variable name to set.
 
 ### Output
-The original collection, with the last element updated to have a new variable name in its tuple.
+The original collection, with the last element updated to have a new variable name
+in its tuple.
 
 ### Examples
 ```julia-repl
 julia> (binops, _final_sym_name) = Syntax.infix_expression_to_binops(:(a + b + c))
-(Tuple{Symbol, Expr}[(Symbol("###1415"), :(a + b)), (Symbol("###1416"), :(var"###1415" + c))], Symbol("###1416"))
+( Tuple{Symbol, Expr}[ (Symbol("###1415"), :(a + b))
+                     , (Symbol("###1416"), :(var"###1415" + c))
+                     ]
+, Symbol("###1416")
+)
 
 julia> binops
 2-element Vector{Tuple{Symbol, Expr}}:
@@ -102,23 +122,33 @@ function is_binop(e::Expr)
     end
 end
 """
-   infix_expression_to_binops(expression :: Expr; gensymbase :: String = "", finalsym :: Union{Nothing, Symbol} = nothing)
+   infix_expression_to_binops( expression :: Expr; gensymbase :: String = ""
+                             , finalsym :: Union{Nothing, Symbol} = nothing)
 
-Convert a nested expression of the form (a * b + c - d / e ...) into a series of binary operations with named values (sym1 = a * b; sym2 = sym1 + c; ...; symn = symn-1 + somevar). If finalsym is given, symn is replaced with the one given.
+Convert a nested expression of the form (a * b + c - d / e ...) into a series of binary
+operations with named values (sym1 = a * b; sym2 = sym1 + c; ...; symn = symn-1 + somevar).
+If finalsym is given, symn is replaced with the one given.
 
 ### Input
 - `expression` -- a single expression containing nested function calls.
 - `gensymbase` -- the base name of the generated interim symbols for each binop
-- `sym`   -- (optional, default: `nothing`) a name for the final result to replace one of the generated symbols. If not given, it will be of the form `Symbol("###<NUMBER>")` e.g. `Symbol("###418")`.
+- `sym`   -- (optional, default: `nothing`) a name for the final result to replace
+             one of the generated symbols. If not given, it will be of the form
+             `Symbol("###<NUMBER>")` e.g. `Symbol("###418")`.
 
 ### Output
-A vector of tuples of variable definitions as symbols and the corresponding Julia expression that calculates the variable.
+A vector of tuples of variable definitions as symbols and the corresponding
+Julia expression that calculates the variable.
 
 ### Examples
 ```julia-repl
 julia> infix_expression_to_binops(:(a + b + c))
 julia> Syntax.infix_expression_to_binops(:(a + b + c))
-(Tuple{Symbol, Expr}[(Symbol("###495"), :(a + b)), (Symbol("###496"), :(var"###495" + c))], Symbol("###496"))
+( Tuple{Symbol, Expr}[ (Symbol("###495"), :(a + b))
+                     , (Symbol("###496"), :(var"###495" + c))
+                     ]
+, Symbol("###496")
+)
 ```
 That is, this converts the expression `a + b + c` into two expressions:
 ```julia
@@ -127,8 +157,13 @@ That is, this converts the expression `a + b + c` into two expressions:
 ```
 
 ```
-julia> Syntax.infix_expression_to_binops(:(a + b + c), gensymbase="generated_variable", lastsym=:infectionRate)
-(Tuple{Symbol, Expr}[(Symbol("##generated_variable#1045"), :(a + b)), (:infectionRate, :(var"##generated_variable#1045" + c))], :infectionRate)
+julia> Syntax.infix_expression_to_binops( :(a + b + c)
+                                        , gensymbase="generated_variable"
+                                        , lastsym=:infectionRate)
+( Tuple{Symbol, Expr}[ (Symbol("##generated_variable#1045"), :(a + b))
+                     , (:infectionRate, :(var"##generated_variable#1045" + c))
+                     ]
+, :infectionRate)
 ```
 That is, this converts the expression `a + b + c` into the expressions:
 ```julia
@@ -137,12 +172,15 @@ infectionRate = generatedVariable#1045 + c
 ```
 This would be used in the case the original expression was `infectionRate = a + b + c`.
 """
-function infix_expression_to_binops(expression::Expr; gensymbase::String="", finalsym::Union{Nothing,Symbol}=nothing)
+function infix_expression_to_binops(
+    expression::Expr;
+    gensymbase::String = "",
+    finalsym::Union{Nothing,Symbol} = nothing,
+)
     exprs::Vector{Tuple{Symbol,Expr}} = []
     function loop(e)
         @match e begin
-            ::Symbol =>
-                e
+            ::Symbol => e
             Expr(:call, f, a, b) => begin
                 asym = loop(a)
                 bsym = loop(b)
@@ -165,7 +203,10 @@ function infix_expression_to_binops(expression::Expr; gensymbase::String="", fin
                 lastsym
             end
             Expr(en, _, _, _) || Expr(en, _, _) => begin
-                throw("Unhandled expression cannot be converted into form f(a, b) " * String(en))
+                throw(
+                    "Unhandled expression cannot be converted into form f(a, b) " *
+                    String(en),
+                )
             end
         end
     end
@@ -181,7 +222,8 @@ end
 """
   extract_function_name_and_args_expr(flow::Expr)
 
-Given a Julia expression of the form f(a), return the symbol :f and the expression, a, the function is being called with.
+Given a Julia expression of the form f(a), return the symbol :f and the expression, a,
+the function is being called with.
 
 ### Input
 - `flow` -- a julia expression of the form f(a)
@@ -197,10 +239,8 @@ julia> Syntax.extract_flow_name_and_equation(:(infectionRate(a + b + c)))
 """
 function extract_function_name_and_args_expr(flow_equation::Expr)
     @match flow_equation begin
-        :($flow_name($expr)) =>
-            (flow_name, expr)
-        :($flow_name($expr, name=$_)) =>
-            (flow_name, expr)
+        :($flow_name($expr)) => (flow_name, expr)
+        :($flow_name($expr, name = $_)) => (flow_name, expr)
         Expr(en, _, _, _) || Expr(en, _, _) =>
             throw("Unhandled expression in flow name definition " * String(en))
     end
@@ -209,13 +249,19 @@ end
 """
     parse_flow_io(flow_definition :: Expr)
 
-Given a flow definition of the form `SYMBOL => flow_name(flow_equation) => SYMBOL`, return a 3-tuple of its constituent parts: the start symbol, the end symbol, and the flow equations's definition as an expression.
+Given a flow definition of the form `SYMBOL => flow_name(flow_equation) => SYMBOL`,
+return a 3-tuple of its constituent parts: the start symbol, the end symbol,
+and the flow equations's definition as an expression.
 
 ### Input
-- `flow_definition` -- A flow definition of the form `SYMBOL => flow_name(flow_equation) => SYMBOL`, where SYMBOL can be an arbitrary name or special cases of ☁ or TODO, which corresponds to a flow from nowhere.
+- `flow_definition` -- A flow definition of the form
+                       `SYMBOL => flow_name(flow_equation) => SYMBOL`,
+                       where SYMBOL can be an arbitrary name or special cases of ☁ or TODO,
+                       which corresponds to a flow from nowhere.
 
 ### Output
-A 3-tuple (input, expression, output) of a an input and output symbol (either of which may be :F_NONE for a flow from nowhere) and the flow equation as a julia expression.
+A 3-tuple (input, expression, output) of a an input and output symbol (either of which
+may be :F_NONE for a flow from nowhere) and the flow equation as a julia expression.
 
 ### Examples
 ```julia-repl
@@ -229,8 +275,7 @@ function parse_flow_io(flow_definition::Expr)
             (:F_NONE, flow, stock_out)
         :($stock_in => $flow => TODO) || :($stock_in => $flow => ☁) =>
             (stock_in, flow, :F_NONE)
-        :($stock_in => $flow => $stock_out) =>
-            (stock_in, flow, stock_out)
+        :($stock_in => $flow => $stock_out) => (stock_in, flow, stock_out)
         Expr(en, _, _, _) || Expr(en, _, _) =>
             throw("Unhandled expression in flow definition " * String(en))
     end
@@ -241,7 +286,8 @@ end
 
 Add a stock to the list of stocks.
 
-Stocks in the Stock and Flow syntax are just a single symbol on a line, so no work is currently done by this function.
+Stocks in the Stock and Flow syntax are just a single symbol on a line, so no work
+is currently done by this function.
 
 ### Input
 - `stocks` -- A list of stocks already parsed from the block
@@ -259,7 +305,8 @@ end
 
 Add a param to the list of params.
 
-Params in the Stock and Flow syntax are just a single symbol on a line, so no work is currently done by this function.
+Params in the Stock and Flow syntax are just a single symbol on a line,
+so no work is currently done by this function.
 
 ### Input
 - `params` -- A list of params already parsed from the block
@@ -275,10 +322,12 @@ end
 """
     parse_dyvar!(dyvars :: Vector{Tuple{Symbol, Expr}}, dyvar :: Expr)
 
-Extract the dynamic variable name and defining expression from a Julia expression of form `dyvar = a + b * c ...`, and add it to the vector of already parsed dynamic variables.
+Extract the dynamic variable name and defining expression from a Julia expression of form
+`dyvar = a + b * c ...`, and add it to the vector of already parsed dynamic variables.
 
 ### Input
-- `dyvars` -- A list of dynamic variables and their defining Julia expressions already parsed from the block
+- `dyvars` -- A list of dynamic variables and their defining Julia expressions
+              already parsed from the block
 - `dyvar` -- A dynamic variable definition of the form `dyvar = defining_expression`
 
 ### Output
@@ -286,8 +335,7 @@ None. This mutates the given dyvars vector.
 """
 function parse_dyvar!(dyvars::Vector{Tuple{Symbol,Expr}}, dyvar::Expr)
     @match dyvar begin
-        :($dyvar_name = $dyvar_def) =>
-            push!(dyvars, (dyvar_name, dyvar_def))
+        :($dyvar_name = $dyvar_def) => push!(dyvars, (dyvar_name, dyvar_def))
         Expr(c, _, _) || Expr(c, _, _, _) =>
             throw("Unhandled expression in dynamic variable definition " * String(c))
     end
@@ -296,7 +344,9 @@ end
 """
     parse_flow!(flows :: Vector{Tuple{Symbol, Expr, Symbol}}, flow :: Expr)
 
-Extract the flow input, output, and defining expression from a Julia expression of form `IN_SYMBOL => FLOW_NAME(FLOW_EQUATION) => OUT_SYMBOL`, and add it to the vector of already parsed flows.
+Extract the flow input, output, and defining expression from a Julia expression of
+the form `IN_SYMBOL => FLOW_NAME(FLOW_EQUATION) => OUT_SYMBOL`,
+and add it to the vector of already parsed flows.
 
 ### Input
 - `flows` -- A list of parsed flows
@@ -313,19 +363,20 @@ end
 """
     parse_sum!(sums :: Vector{Tuple{Symbol, Vector{Symbol}}}, sum :: Expr)
 
-Extract the sum name and the stocks that flow into it from a stock expression of the form `SUM_NAME = [STOCK_1, STOCK_2, STOCK_3, ...]`
+Extract the sum name and the stocks that flow into it from a stock expression of the form
+`SUM_NAME = [STOCK_1, STOCK_2, STOCK_3, ...]`
 
 ### Input
 - `sums` -- A list of parsed sum names and their incoming stocks
-- `sum`  -- A sum definition as a Julia expression of the form `sum_name = [stock_1, stock_2, stock_3, ...]`
+- `sum`  -- A sum definition as a Julia expression of the form
+            `sum_name = [stock_1, stock_2, stock_3, ...]`
 
 ### Output
 None. This mutates the given sums vector.
 """
 function parse_sum!(sums::Vector{Tuple{Symbol,Vector{Symbol}}}, sum::Expr)
     @match sum begin
-        :($sum_name = $equation) =>
-            push!(sums, (sum_name, equation.args))
+        :($sum_name = $equation) => push!(sums, (sum_name, equation.args))
         Expr(c, _, _) || Expr(c, _, _, _) =>
             throw("Unhandled expression in sum defintion " * String(c))
     end
@@ -334,13 +385,16 @@ end
 """
     parse_stock_and_flow_syntax(statements :: Vector{Any})
 
-Given a vector of Julia expressions, attempt to interpret them using the block syntax defined for Stock and Flow diagrams.
+Given a vector of Julia expressions, attempt to interpret them using the block syntax
+defined for Stock and Flow diagrams.
 
 ### Input
-- `statements` -- A series of Julia expressions, each a line of code in a block of statements.
+- `statements` -- A series of Julia expressions, each a line of code in
+                  a block of statements.
 
 ### Output
-A StockAndFlowSyntax data type which contains the syntax pieces required to define a Stock and Flow model: stocks, parameters, dynamic variables, flows, and sums.
+A StockAndFlowSyntax data type which contains the syntax pieces required to define
+a Stock and Flow model: stocks, parameters, dynamic variables, flows, and sums.
 """
 function parse_stock_and_flow_syntax(statements::Vector{Any})
     stocks::Vector{Symbol} = []
@@ -368,19 +422,20 @@ function parse_stock_and_flow_syntax(statements::Vector{Any})
             end
             QuoteNode(kw) =>
                 throw("Unknown block type for Stock and Flow syntax: " * String(kw))
-            _ =>
-                current_phase(statement)
+            _ => current_phase(statement)
         end
     end
 
-    s = StockAndFlowSyntax(stocks, params, dyvars, flows, sums)
+    s = StockAndFlowBlock(stocks, params, dyvars, flows, sums)
     return s
 end
 
 """
     fnone_or_tuple(arrows :: Vector{Symbol})
 
-Given a vector of arrow names, modify it into suitable input for a StockAndFlowF data type: :F_NONE for an empty vector, the value alone for a singleton vector, and the vector itself if there are multiple arrows given.
+Given a vector of arrow names, modify it into suitable input for a StockAndFlowF data type:
+:F_NONE for an empty vector, the value alone for a singleton vector,
+and the vector itself if there are multiple arrows given.
 
 ### Input
 - `arrows` -- A vector of symbols which represents some of the arrows for a stock.
@@ -403,19 +458,31 @@ function fnone_value_or_vector(arrows::Vector{Symbol})
 end
 
 """
-    assemble_stock_definitions(stocks::Vector{Symbol}, flows::Vector{Tuple{Symbol,Expr,Symbol}}, sum_variables::Vector{Tuple{Symbol,Vector{Symbol}}})
+    assemble_stock_definitions( stocks::Vector{Symbol}
+                              , flows::Vector{Tuple{Symbol,Expr,Symbol}}
+                              , sum_variables::Vector{Tuple{Symbol,Vector{Symbol}}}
+                              )
 
-Convert the raw syntax of a Stock and Flow block definition into a series of stock definitions suitable for input into the StockAndFlowF data type, which is (:STOCK_NAME => ((INPUT_ARROWS,...), (OUTPUT_ARROWS,...), (SUM_ARROWS,...))). The input, output, and sum arrows are calculated from the sum and flow definitions.
+Convert the raw syntax of a Stock and Flow block definition into a series of stock
+definitions suitable for input into the StockAndFlowF data type, which is
+(:STOCK_NAME => ((INPUT_ARROWS,...), (OUTPUT_ARROWS,...), (SUM_ARROWS,...))).
+The input, output, and sum arrows are calculated from the sum and flow definitions.
 
 ### Input
 - `stocks` -- A list of stock names as symbols
-- `flows` -- A list of flow definitions, which may use any of the stock names as inputs or outputs.
+- `flows` -- A list of flow definitions, which may use any of the stock names as
+             inputs or outputs.
 - `sum_variables` -- A list of sum definitions.
 
 ### Output
-The raw syntax definitions of a Stock and Flow block rearranged into a StockAndFlowF stock definition vector.
+The raw syntax definitions of a Stock and Flow block rearranged into a
+StockAndFlowF stock definition vector.
 """
-function assemble_stock_definitions(stocks::Vector{Symbol}, flows::Vector{Tuple{Symbol,Expr,Symbol}}, sum_variables::Vector{Tuple{Symbol,Vector{Symbol}}})
+function assemble_stock_definitions(
+    stocks::Vector{Symbol},
+    flows::Vector{Tuple{Symbol,Expr,Symbol}},
+    sum_variables::Vector{Tuple{Symbol,Vector{Symbol}}},
+)
     formatted_stocks = []
     for stock in stocks
         input_arrows::Vector{Symbol} = []
@@ -435,7 +502,16 @@ function assemble_stock_definitions(stocks::Vector{Symbol}, flows::Vector{Tuple{
                 push!(sum_arrows, sum_variable_name)
             end
         end
-        push!(formatted_stocks, (stock => (fnone_value_or_vector(input_arrows), fnone_value_or_vector(output_arrows), fnone_value_or_vector(sum_arrows))))
+        push!(
+            formatted_stocks,
+            (
+                stock => (
+                    fnone_value_or_vector(input_arrows),
+                    fnone_value_or_vector(output_arrows),
+                    fnone_value_or_vector(sum_arrows),
+                )
+            ),
+        )
     end
     return formatted_stocks
 end
@@ -443,10 +519,13 @@ end
 """
     dyvar_exprs_to_symbolic_repr(dyvars::Vector{Tuple{Symbol,Expr}})
 
-Converts a series of dynamic variable definitions of the form `dyvar = dyvar_expression` into a form suitable for input into the StockAndFlowF data type: (:dyvar => ((:arg1, :arg2) => :function_name))
+Converts a series of dynamic variable definitions of the form `dyvar = dyvar_expression`
+into a form suitable for input into the StockAndFlowF data type:
+(:dyvar => ((:arg1, :arg2) => :function_name))
 
 ### Input
-- `dyvars` -- A vector of pairs of dynamic variable names (as symbols) and Julia expressions defining them.
+- `dyvars` -- A vector of pairs of dynamic variable names (as symbols)
+              and Julia expressions defining them.
 
 ### Output
 A vector of dynamic variable definitions suitable for input to StockAndFlowF.
@@ -459,11 +538,13 @@ function dyvar_exprs_to_symbolic_repr(dyvars::Vector{Tuple{Symbol,Expr}})
                 Expr(:call, op, a, b) => begin
                     push!(syms, (dyvar_name => ((a, b) => op)))
                 end
-                Expr(c, _, _) || Expr(c, _, _, _) =>
-                    throw("Unhandled expression in dynamic variable definition " * String(c))
+                Expr(c, _, _) || Expr(c, _, _, _) => throw(
+                    "Unhandled expression in dynamic variable definition " * String(c),
+                )
             end
         else
-            (binops, _) = infix_expression_to_binops(dyvar_definition, finalsym=dyvar_name)
+            (binops, _) =
+                infix_expression_to_binops(dyvar_definition, finalsym = dyvar_name)
             binops_syms = dyvar_exprs_to_symbolic_repr(binops)
             syms = vcat(syms, binops_syms)
         end
@@ -474,18 +555,22 @@ end
 """
     flow_expr_to_symbolic_repr(flow_expression :: Expr, dyvar_names :: Vector{Symbol})
 
-Converts a flow definition from one of three forms into a format suitable for input to StockAndFlowF data types:
+Converts a flow definition from one of three forms into a format suitable
+for input to StockAndFlowF data types:
 
 - `flow_name(name)` -- uses the dynamic variable `name` as the flow equation
-- `flow_name(expr)` -- hoists the expr out as a dynamic variable and replaces it with the generated name
-- `flow_name(expr, name=name)` -- hoists the expr out as a dynamic variable and replaces it with the given name
+- `flow_name(expr)` -- hoists the expr out as a dynamic variable and replaces
+                       it with the generated name
+- `flow_name(expr, name=name)` -- hoists the expr out as a dynamic variable and replaces
+                                  it with the given name
 
 ### Input
 - `flow_expression` -- a flow definition equation from Stock and Flow syntax
 - `dyvar_names` -- a vector of symbols that the flow_expression may be referring to
 
 ### Output
-The flow_expression's representation StockAndFlowF parameter format: `flow_name => dynamic_variable`
+The flow_expression's representation StockAndFlowF parameter format:
+`flow_name => dynamic_variable`
 """
 function flow_expr_to_symbolic_repr(flow_expression, dyvar_names)
     @match flow_expression begin
@@ -502,8 +587,8 @@ function flow_expr_to_symbolic_repr(flow_expression, dyvar_names)
                 return (dyvs, flow_name => var_name)
             end
         end
-        :($flow_name($expr, name=$sym)) => begin
-            (additional_dyvars, var_name) = infix_expression_to_binops(expr, finalsym=sym)
+        :($flow_name($expr, name = $sym)) => begin
+            (additional_dyvars, var_name) = infix_expression_to_binops(expr, finalsym = sym)
             dyvs = dyvar_exprs_to_symbolic_repr(additional_dyvars)
             return (dyvs, flow_name => sym)
         end
@@ -514,16 +599,22 @@ function flow_expr_to_symbolic_repr(flow_expression, dyvar_names)
 end
 
 """
-    create_flow_definitions(flows::Vector{Tuple{Symbol,Expr,Symbol}}, dyvar_names :: Vector{Symbol})
+    create_flow_definitions( flows::Vector{Tuple{Symbol,Expr,Symbol}}
+                           , dyvar_names :: Vector{Symbol}
+                           )
 
-Assemble the flow parameters for a StockAndFlowF data type from definitions of the form `input_stock => flow_name(flow_equation) => output_stock`.
+Assemble the flow parameters for a StockAndFlowF data type from definitions of the form
+`input_stock => flow_name(flow_equation) => output_stock`.
 
 ### Input
-- `flows` -- A vector of flow definitions in the form of 3-tuple `(input_stock, flow_expr, output_stock)
+- `flows` -- A vector of flow definitions in the form of 3-tuple
+             `(input_stock, flow_expr, output_stock)
 - `dyvar_names` -- A vector of known dynamic variable names
 
 ### Output
-A 2-tuple containing in the first cell the flow definitions of the form `flow_name => dynamic_variable_name`, and in the second cell any dynamic variables generated in generating the flow definitions.
+A 2-tuple containing in the first cell the flow definitions of the form
+`flow_name => dynamic_variable_name`, and in the second cell any dynamic variables
+generated in generating the flow definitions.
 """
 function create_flow_definitions(flows::Vector{Tuple{Symbol,Expr,Symbol}}, dyvar_names)
     flow_definitions = []
@@ -544,26 +635,34 @@ end
 Extract the names of the sum variables from its syntax elements.
 
 ### Input
-`sum_syntax_elements` -- A vector of 2-tuples of the sum variable's name and its constituent stocks.
+`sum_syntax_elements` -- A vector of 2-tuples of the sum variable's name and
+                         its constituent stocks.
 
 ### Output
 A vector of sum variable names.
 """
-sum_variables(sum_syntax_elements) = [sum_name for (sum_name, _sum_definition) in sum_syntax_elements]
+sum_variables(sum_syntax_elements) =
+    [sum_name for (sum_name, _sum_definition) in sum_syntax_elements]
 
 """
     stock_and_flow_syntax_to_arguments(syntax_elements::StockAndFlowSyntax)
 
-Convert the Stock and Flow Syntax elements to parameters suitable for StockAndFlowF data type instantiation
+Convert the Stock and Flow Syntax elements to parameters suitable for StockAndFlowF
+data type instantiation
 
 ### Input
-- `syntax_elements` -- The output from `parse_stock_and_flow_syntax`, containing the definition of a stock and flow model
+- `syntax_elements` -- The output from `parse_stock_and_flow_syntax`,
+                       containing the definition of a stock and flow model
 
 ### Output
 Parameters for instantiation of a StockAndFlowF data type.
 """
-function stock_and_flow_syntax_to_arguments(syntax_elements::StockAndFlowSyntax)
-    stocks = assemble_stock_definitions(syntax_elements.stocks, syntax_elements.flows, syntax_elements.sums)
+function stock_and_flow_syntax_to_arguments(syntax_elements::StockAndFlowBlock)
+    stocks = assemble_stock_definitions(
+        syntax_elements.stocks,
+        syntax_elements.flows,
+        syntax_elements.sums,
+    )
     params = syntax_elements.params
     dyvars = dyvar_exprs_to_symbolic_repr(syntax_elements.dyvars)
     dyvar_names = [dyvar_name for (dyvar_name, _dyvar_def) in dyvars]
@@ -608,16 +707,29 @@ macro stock_and_flow(block)
     Base.remove_linenums!(block)
     syntax_lines = parse_stock_and_flow_syntax(block.args)
     saff_args = stock_and_flow_syntax_to_arguments(syntax_lines)
-    return StockAndFlowF(saff_args.stocks, saff_args.params, saff_args.dyvars, saff_args.flows, saff_args.sums)
+    return StockAndFlowF(
+        saff_args.stocks,
+        saff_args.params,
+        saff_args.dyvars,
+        saff_args.flows,
+        saff_args.sums,
+    )
 end
 
 # Current model definition:
-SIR_curr = StockAndFlowF((:S => (:F_NONE, :inf, :N), :I => (:inf, :rec, :N), :R => (:rec, :F_NONE, :N)),# stocks
+SIR_curr = StockAndFlowF(
+    (:S => (:F_NONE, :inf, :N), :I => (:inf, :rec, :N), :R => (:rec, :F_NONE, :N)),# stocks
     (:c, :beta, :tRec),# parameters
-    (:v_prevalence => ((:I, :N) => :/), :v_meanInfectiousContactsPerS => ((:c, :v_prevalence) => :*), :v_perSIncidenceRate => ((:beta, :v_meanInfectiousContactsPerS) => :*),
-        :v_newInfections => ((:S, :v_perSIncidenceRate) => :*), :v_newRecovery => ((:I, :tRec) => :/)),# dynamical variables
+    (# dynamical variables
+        :v_prevalence => ((:I, :N) => :/),
+        :v_meanInfectiousContactsPerS => ((:c, :v_prevalence) => :*),
+        :v_perSIncidenceRate => ((:beta, :v_meanInfectiousContactsPerS) => :*),
+        :v_newInfections => ((:S, :v_perSIncidenceRate) => :*),
+        :v_newRecovery => ((:I, :tRec) => :/),
+    ),
     (:inf => :v_newInfections, :rec => :v_newRecovery),# flows
-    (:N))# sum dynamical variables
+    (:N),# sum dynamical variables
+)
 
 # New syntax
 SIR = @stock_and_flow begin


### PR DESCRIPTION
## Description

In the target branch of this pull request, `functionStructureInSchema`, a new data type, `StockAndFlowF`, has been added to allow for the flow equations of a Stock and Flow model to be captured in the model itself instead of as separate Julia equations. This gives rise to a new difficulty in definition of models: it is very tedious to specify the equations in this new form. One must manually write out the equations as symbolic expressions of tuples, like so:

``` julia
SIR = StockAndFlowF(
    # stocks
    (:S => (:F_NONE, :inf, :N), :I => (:inf, :rec, :N), :R => (:rec, :F_NONE, :N)),
    # parameters
    (:c, :beta, :tRec),
    # dynamical variables
    (   :v_prevalence => ((:I, :N) => :/),
        :v_meanInfectiousContactsPerS => ((:c, :v_prevalence) => :*),
        :v_perSIncidenceRate => ((:beta, :v_meanInfectiousContactsPerS) => :*),
        :v_newInfections => ((:S, :v_perSIncidenceRate) => :*),
        :v_newRecovery => ((:I, :tRec) => :/),
    ),
    # flows
    (:inf => :v_newInfections, :rec => :v_newRecovery),
    # sum dynamical variables
    (:N),
)
```

Notable difficulties with this syntax are:
- Having to manually convert equations to binary-operation forms (`tmp1 = a + b; tmp2 = tmp1 + c; tmp3 = tmp2 + d; tmp4 = tmp3 + e`) rather than just specifying what you mean like `f = a + b + c + d + e`
- Having to prefix everything as keywords (e.g. `:varName`) rather than just naming things (e.g. `varName`)
- Stocks in this syntax appear to actually define a lot of the flow logic; e.g. `:S => (:F_NONE, :inf, :N)`, so understanding what has an arrow from where is less direct
- Having to keep track of all those nested tuples

## Changes

Add a macro `stock_and_flow` in a new module `Syntax` which allows Stock and Flow models to be defined using a more configuration language style syntax, e.g.

``` julia
SIR = @stock_and_flow begin
    :stocks
      S
      I
      R

    :parameters
      c
      beta
      tRec

    :dynamic_variables
      v_prevalence = I / N
      v_meanInfectiousContactsPerS = c * v_prevalence
      v_perSIncidenceRate = beta * v_meanInfectiousContactsPerS
      v_newInfections = S * v_perSIncidenceRate
      v_newRecovery = I / tRec

    :flows
      S => inf(v_newInfections) => I
      I => rec(v_newRecovery) => R

    :sums
      N = [S, I, R]
end
```

This new syntax has a couple 'syntactic sugar' features:

- In the current syntax, flows are just an arrow `:flowName => :dynamicVariableName`, and the actual flow equation is specified as a dynamic variable; with this new syntax, dynamic variables can be inferred, and the flow can have an equation specifically on it.
- In the current syntax, dynamic variable equations must be converted into a series of binary operations; with this new syntax, flow equations and dynamic variables can refer to as many variables as you wish, and the 'binop' form will be inferred.

As an example, see this version of the model which is the same as the other two above:

```julia
SIR = @stock_and_flow begin
    :stocks
      S
      I
      R

    :parameters
      c
      beta
      tRec
    
    # We can leave out dynamic variables and 
    # let them be inferred from flows entirely!
    
    :flows
      S => inf(S * beta * (c * (I / N))) => I
      I => rec(I / tRec) => R
    
    :sums
      N = [S, I, R]
end
```

## Testing

When written in the longer form (see the second example) so that all of the variable names match, you will find the first two models are `==`, partially confirming the transformations performed.

When written in the shorter form, the variables are all inferred, so it's less clear it's the same model. There may be bugs in the implementation.

I would like to request testing suggestions from @Xiaoyan-Li especially because this has not been thoroughly tested and may contain many bugs. 

## ~TODOs / Discussion~

- ~Clouds (`☁`) all currently resolve to `:F_NONE`. There is no differentiation between them. Is there a way to differentiate between them as input to `StockAndFlowF`?~ 
    - This was discussed in a Zoom meeting & this is just how the library works. 
- ~An ascii keyword would be nice for people who don't want to copy and paste a `☁`; right now, that keyword is simply `TODO`, which isn't desirable. What should it be? `NOTHING`? `FNONE`? `THE_GREAT_VOID`?~
    - Discussed in a Zoom meeting and addressed in [078fb54](https://github.com/AlgebraicJulia/StockFlow.jl/pull/15/commits/078fb549cb040863e30e65b136ded7ae2f004e76) 
- ~In the new model definition form, dynamic variables are inferred, and given generated symbol names. This means that the variables that show up when the new models are `Graph`'d look like~
    - This was discussed in a Zoom meeting and we decided to use the flow or dyvar name as a base for generated variables. See d026566 and 4d63d06 and https://github.com/AlgebraicJulia/StockFlow.jl/pull/15#issuecomment-1428533992
    - (Edited this comment to remove discussion of point 3 to reduce noise since it has been addressed.)

### Note on differences

You may notice in the two `Graph` diagrams above a strange arrow in the new version not in the original: this is an artifact of the 'binop' stage, but should be the same model. Specifically:

- `##672 = v_prevalence = I / N`
- `##673 =  v_meanInfectiousContactPerS = c * ##672`
- `##674 = S * beta` -- this is part of `v_newInfections` pulled out, the artifact mentioned.
- `##675 = v_newInfections = ##674 * ##672`
- `##676 = v_newRecovery = I / tRec`

That is, `v_newInfections = S * v_perSIncidenceRate` == `v_newInfections = S * beta * c * (I / N)`.

As far as I can tell, despite the differences in the appearance of the models when `Graph`'d, they are the same model encoded slightly differently.

## Further examples

Dr Nathaniel Osgood gave, as an example of the desired syntax, this model definition:

``` julia
SIR_3 = @stock_and_flow begin
    :stocks
    S
    I
    R

    :parameters
    c
    beta
    tRec
    omega
    alpha

    :dynamic_variables
    v_prevalence = I / totalPopulation
    v_forceOfInfection = c * v_prevalence * beta

    :flows
    S => inf(S * v_forceOfInfection) => I
    ☁ => births(totalPopulation * alpha) => S
    S => deathsS(S * omega) => ☁
    I => rec(I / tRec) => R
    I => deathsI(I * omega) => ☁
    R => deathsR(R * omega) => ☁


    :sums
    totalPopulation = [S, I, R]
end
```

This syntax now defines an SIR model when used this macro, and when `Graph`'d, looks like:

![sir_3](https://user-images.githubusercontent.com/6503910/218145411-4df1327b-4d20-4fa2-a728-c19af2aa7bbe.png)

This may not be exactly _right_ but I'm not sure how to verify the changes (see the testing section of this PR).

### FYI

@Xiaoyan-Li @ndo885 