### PR TITLE
Add tests of the Syntax module and fix bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ examples/full_fledged_schema_examples/composition/.ipynb_checkpoints/
 examples/full_fledged_schema_examples/stratification/.ipynb_checkpoints/
 
 examples/full_fledged_schema_examples/CaulsalLoopDiagrams/.ipynb_checkpoints/
+
+Manifest.toml
+.#*

--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,7 @@ authors = ["Xiaoyan Li <xiaoyan.lyu.li@gmail.com>"]
 version = "0.1.0"
 
 [deps]
-AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
-Chain = "8be319e6-bccf-4806-a6f7-6fae938471bc"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 CompTime = "0fb5dd42-039a-4ca4-a1d7-89a96eae6d39"
 GraphViz = "f526b714-d49f-11e8-06ff-31ed36ee7ee0"
@@ -25,9 +23,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-AutoHashEquals = "^0.2.0"
 Catlab = "0.14.1"
-Chain = "0.5.0"
 Combinatorics = "1.0.2"
 CompTime = "0.1"
 GraphViz = "0.2"

--- a/src/StockFlow.jl
+++ b/src/StockFlow.jl
@@ -1,11 +1,11 @@
 module StockFlow
 
-export TheoryStockAndFlow0, TheoryStockAndFlow, TheoryStockAndFlowStructure, TheoryStockAndFlowStructureF, TheoryStockAndFlowF, AbstractStockAndFlow0, AbstractStockAndFlow, AbstractStockAndFlowStructure, 
-AbstractStockAndFlowStructureF, AbstractStockAndFlowF, StockAndFlow0, StockAndFlow, StockAndFlowStructure, StockAndFlowStructureF, StockAndFlowF, add_flow!, add_flows!, add_stock!, add_stocks!, 
+export TheoryStockAndFlow0, TheoryStockAndFlow, TheoryStockAndFlowStructure, TheoryStockAndFlowStructureF, TheoryStockAndFlowF, AbstractStockAndFlow0, AbstractStockAndFlow, AbstractStockAndFlowStructure,
+AbstractStockAndFlowStructureF, AbstractStockAndFlowF, StockAndFlow0, StockAndFlow, StockAndFlowStructure, StockAndFlowStructureF, StockAndFlowF, add_flow!, add_flows!, add_stock!, add_stocks!,
 add_variable!, add_variables!, add_svariable!, add_svariables!, add_parameter!, add_parameters!, add_VVlink!, add_VVlinks!,
 add_inflow!, add_inflows!, add_outflow!, add_outflows!, add_Vlink!, add_Vlinks!, add_Slink!, add_Slinks!, add_SVlink!, add_Plink!, add_Plinks!,
-add_SVlinks!, ns, nf, ni, no, nvb, nsv, nls, nlv, nlsv, np, nlpv,nlvv,sname, fname, svname, svnames, vname, inflows, outflows, svStocks, 
-funcDynam, flowVariableIndex, funcFlow, funcFlows, funcSV, funcSVs, TransitionMatrices, 
+add_SVlinks!, ns, nf, ni, no, nvb, nsv, nls, nlv, nlsv, np, nlpv,nlvv,sname, fname, svname, svnames, vname, inflows, outflows, svStocks,
+funcDynam, flowVariableIndex, funcFlow, funcFlows, funcSV, funcSVs, TransitionMatrices,
 vectorfield, funcFlowsRaw, funcFlowRaw, inflowsAll, outflowsAll,instock,outstock, stockssv, stocksv, svsv, svsstock,
 vsstock, vssv, svsstockAllF, vsstockAllF, vssvAllF, StockAndFlowUntyped, StockAndFlowFUntyped, StockAndFlowStructureUntyped, StockAndFlowStructureFUntyped, StockAndFlowUntyped0, Open, snames, fnames, svnames, vnames,
 object_shift_right, foot, leg, lsnames, OpenStockAndFlow, OpenStockAndFlowOb, fv, fvs, nlvv, nlpv, vtgt, vsrc, vpsrc, vptgt, pname, pnames, make_v_expr,
@@ -61,7 +61,7 @@ can refer to:
 https://docs.julialang.org/en/v1/manual/mathematical-operations/
 =#
 
-Operators = Dict(2 => [:+, :-, :*, :/, :÷, :^, :%, :log, Symbol("")], 
+Operators = Dict(2 => [:+, :-, :*, :/, :÷, :^, :%, :log, Symbol("")],
                  1 => [:log, :exp, :sqrt, Symbol("")]) #:NN is for NONE, which is used in create the special diagram using graph rewriting
 
 
@@ -81,32 +81,32 @@ math_expr(op, op1) = Expr(:call, op, op1)
 
 # Attributes:
   Name::AttrType
-  
+
   sname::Attr(S, Name)
   svname::Attr(SV, Name)
 end
 
 @abstract_acset_type AbstractStockAndFlow0
 @acset_type StockAndFlowUntyped0(TheoryStockAndFlow0, index=[:lss,:lssv]) <: AbstractStockAndFlow0
-# constrains the attributes data type to be: 
+# constrains the attributes data type to be:
 # 2. Name: Symbol
-const StockAndFlow0 = StockAndFlowUntyped0{Symbol} 
+const StockAndFlow0 = StockAndFlowUntyped0{Symbol}
 
 # for an instance of the sub-schema, the program supports only have stocks, or only have sum auxiliary variables, or both stocks
-# and sum auxiliary variables, or have both 
+# and sum auxiliary variables, or have both
 StockAndFlow0(s,sv,ssv) = begin
   p0 = StockAndFlow0()
   s = vectorify(s)
   sv = vectorify(sv)
   ssv = vectorify(ssv)
 
-  if length(s)>0    
+  if length(s)>0
     s_idx=state_dict(s)
     add_stocks!(p0, length(s), sname=s)
   end
 
-  if length(sv)>0   
-    sv_idx=state_dict(sv) 
+  if length(sv)>0
+    sv_idx=state_dict(sv)
     add_svariables!(p0, length(sv), svname=sv)
   end
 
@@ -147,11 +147,11 @@ end
 
 @abstract_acset_type AbstractStockAndFlowStructure <: AbstractStockAndFlow0
 @acset_type StockAndFlowStructureUntyped(TheoryStockAndFlowStructure, index=[:is,:os,:ifn,:ofn,:fv,:lvs,:lvv,:lsvsv,:lsvv,:lss,:lssv]) <: AbstractStockAndFlowStructure
-# constrains the attributes data type to be: 
+# constrains the attributes data type to be:
 # 1. InitialValue: Real
 # 2. Name: Symbol
 # Note: those three (or any subgroups) attributes' datatype can be defined by the users. See the example of the PetriNet which allows the Reactionrate and Concentration defined by the users
-const StockAndFlowStructure = StockAndFlowStructureUntyped{Symbol} 
+const StockAndFlowStructure = StockAndFlowStructureUntyped{Symbol}
 
 
 ###### TODO #### delete??
@@ -164,7 +164,7 @@ end
 
 @abstract_acset_type AbstractStockAndFlow <: AbstractStockAndFlowStructure
 @acset_type StockAndFlowUntyped(TheoryStockAndFlow, index=[:is,:os,:ifn,:ofn,:fv,:lvs,:lvv,:lsvsv,:lsvv,:lss,:lssv]) <: AbstractStockAndFlow
-const StockAndFlow = StockAndFlowUntyped{Symbol,Function} 
+const StockAndFlow = StockAndFlowUntyped{Symbol,Function}
 
 
 # define the schema of a general stock and flow diagram
@@ -211,13 +211,13 @@ const StockAndFlowF = StockAndFlowFUntyped{Symbol,Symbol,Int8}
 add_flow!(p::AbstractStockAndFlowStructure,v;kw...) = add_part!(p,:F;fv=v,kw...)
 add_flows!(p::AbstractStockAndFlowStructure,v,n;kw...) = add_parts!(p,:F,n;fv=v,kw...)
 
-add_stock!(p::AbstractStockAndFlow0;kw...) = add_part!(p,:S;kw...) 
+add_stock!(p::AbstractStockAndFlow0;kw...) = add_part!(p,:S;kw...)
 add_stocks!(p::AbstractStockAndFlow0,n;kw...) = add_parts!(p,:S,n;kw...)
 
-add_variable!(p::AbstractStockAndFlowStructure;kw...) = add_part!(p,:V;kw...) 
+add_variable!(p::AbstractStockAndFlowStructure;kw...) = add_part!(p,:V;kw...)
 add_variables!(p::AbstractStockAndFlowStructure,n;kw...) = add_parts!(p,:V,n;kw...)
 
-add_svariable!(p::AbstractStockAndFlow0;kw...) = add_part!(p,:SV;kw...) 
+add_svariable!(p::AbstractStockAndFlow0;kw...) = add_part!(p,:SV;kw...)
 add_svariables!(p::AbstractStockAndFlow0,n;kw...) = add_parts!(p,:SV,n;kw...)
 
 add_inflow!(p::AbstractStockAndFlowStructure,s,t;kw...) = add_part!(p,:I;is=s,ifn=t,kw...)
@@ -386,10 +386,10 @@ StockAndFlow(s,f,v,sv) = begin
     p
 end
 
-add_parameter!(p::AbstractStockAndFlowStructureF;kw...) = add_part!(p,:P;kw...) 
+add_parameter!(p::AbstractStockAndFlowStructureF;kw...) = add_part!(p,:P;kw...)
 add_parameters!(p::AbstractStockAndFlowStructureF,n;kw...) = add_parts!(p,:P,n;kw...)
 
-add_variable!(p::AbstractStockAndFlowStructureF;kw...) = add_part!(p,:V;kw...) 
+add_variable!(p::AbstractStockAndFlowStructureF;kw...) = add_part!(p,:V;kw...)
 add_variables!(p::AbstractStockAndFlowStructureF,n;kw...) = add_parts!(p,:V,n;kw...)
 
 add_VVlink!(p::AbstractStockAndFlowStructureF,vs,vt;kw...) = add_part!(p,:LVV;lvsrc=vs,lvtgt=vt,kw...)
@@ -420,9 +420,9 @@ StockAndFlowStructureF(s,p,v,f,sv) = begin
   sv_idx = state_dict(sv)
 
   add_parameters!(sf,length(p),pname=p)
-  add_svariables!(sf, length(sv), svname=sv) 
-  add_variables!(sf, length(vname), vname=vname) 
-  add_flows!(sf,map(x->v_idx[x], map(last,f)),length(fname),fname=fname) 
+  add_svariables!(sf, length(sv), svname=sv)
+  add_variables!(sf, length(vname), vname=vname)
+  add_flows!(sf,map(x->v_idx[x], map(last,f)),length(fname),fname=fname)
 
 
   # Parse the elements included in "s" -- stocks
@@ -449,10 +449,10 @@ StockAndFlowStructureF(s,p,v,f,sv) = begin
 
   # Parse the elements included in "v" -- auxiliary vairables
   for (vn,args) in v
-    
+
     args=vectorify(args)
 #    @assert op in Operators[length(args)]
-    
+
     for (i,arg) in enumerate(args)
       if arg in sname
         add_Vlink!(sf, s_idx[arg], v_idx[vn])
@@ -500,9 +500,9 @@ StockAndFlowF(s,p,v,f,sv) = begin
   sv_idx = state_dict(sv)
 
   add_parameters!(sf,length(p),pname=p)
-  add_svariables!(sf, length(sv), svname=sv) 
-  add_variables!(sf, length(vname), vname=vname, vop=op) 
-  add_flows!(sf,map(x->v_idx[x], map(last,f)),length(fname),fname=fname) 
+  add_svariables!(sf, length(sv), svname=sv)
+  add_variables!(sf, length(vname), vname=vname, vop=op)
+  add_flows!(sf,map(x->v_idx[x], map(last,f)),length(fname),fname=fname)
 
 
   # Parse the elements included in "s" -- stocks
@@ -529,10 +529,10 @@ StockAndFlowF(s,p,v,f,sv) = begin
 
   # Parse the elements included in "v" -- auxiliary vairables
   for (vn,(args,op)) in v
-    
+
     args=vectorify(args)
 #    @assert op in Operators[length(args)]
-    
+
     for (i,arg) in enumerate(args)
       if arg in sname
         add_Vlink!(sf, s_idx[arg], v_idx[vn], lvsposition=i)
@@ -576,26 +576,26 @@ lsnames(p::AbstractStockAndFlow0) = begin
 end
 
 # return inflows of stock index s
-inflows(p::AbstractStockAndFlowStructure,s) = subpart(p,incident(p,s,:is),:ifn) 
+inflows(p::AbstractStockAndFlowStructure,s) = subpart(p,incident(p,s,:is),:ifn)
 # return outflows of stock index s
-outflows(p::AbstractStockAndFlowStructure,s) = subpart(p,incident(p,s,:os),:ofn) 
+outflows(p::AbstractStockAndFlowStructure,s) = subpart(p,incident(p,s,:os),:ofn)
 # return stocks of flow index f flow in
 # TODO: add assertion that the length(instock)=1
-instock(p::AbstractStockAndFlowStructure,f) = subpart(p,incident(p,f,:ifn),:is) 
+instock(p::AbstractStockAndFlowStructure,f) = subpart(p,incident(p,f,:ifn),:is)
 # return stocks of flow index f flow out
 # TODO: add assertion that the length(outstock)=1
-outstock(p::AbstractStockAndFlowStructure,f) = subpart(p,incident(p,f,:ofn),:os) 
+outstock(p::AbstractStockAndFlowStructure,f) = subpart(p,incident(p,f,:ofn),:os)
 # return stocks of sum variable index sv link to
-stockssv(p::AbstractStockAndFlow0,sv) = subpart(p,incident(p,sv,:lssv),:lss) 
+stockssv(p::AbstractStockAndFlow0,sv) = subpart(p,incident(p,sv,:lssv),:lss)
 # return stocks of auxiliary variable index v link to
-stocksv(p::AbstractStockAndFlowStructure,v) = subpart(p,incident(p,v,:lvv),:lvs) 
+stocksv(p::AbstractStockAndFlowStructure,v) = subpart(p,incident(p,v,:lvv),:lvs)
 # return sum variables of auxiliary variable index v link to
-svsv(p::AbstractStockAndFlowStructure,v) = subpart(p,incident(p,v,:lsvv),:lsvsv) 
-# return sum auxiliary variables a stock s link 
+svsv(p::AbstractStockAndFlowStructure,v) = subpart(p,incident(p,v,:lsvv),:lsvsv)
+# return sum auxiliary variables a stock s link
 svsstock(p::AbstractStockAndFlowStructure,s) = subpart(p,incident(p,s,:lss),:lssv)
-# return auxiliary variables a stock s link 
+# return auxiliary variables a stock s link
 vsstock(p::AbstractStockAndFlowStructure,s) = subpart(p,incident(p,s,:lvs),:lvv)
-# return auxiliary variables a sum auxiliary variable link 
+# return auxiliary variables a sum auxiliary variable link
 vssv(p::AbstractStockAndFlowStructure,sv) = subpart(p,incident(p,sv,:lsvsv),:lsvv)
 
 
@@ -612,13 +612,13 @@ vptgt(p::AbstractStockAndFlowStructureF,pp) = subpart(p,incident(p,pp,:lpvp),:lp
 # return operator of an auxiliary variable
 vop(p::AbstractStockAndFlowF,v) = subpart(p,v,:vop)
 # return argument position of source stock variable of an auxiliary variable
-lvvposition(p::AbstractStockAndFlowF,v) = subpart(p,incident(p,v,:lvv),:lvsposition) 
+lvvposition(p::AbstractStockAndFlowF,v) = subpart(p,incident(p,v,:lvv),:lvsposition)
 # return argument position of source auxiliary variable of an auxiliary variable
-lvtgtposition(p::AbstractStockAndFlowF,v) = subpart(p,incident(p,v,:lvtgt),:lvsrcposition) 
+lvtgtposition(p::AbstractStockAndFlowF,v) = subpart(p,incident(p,v,:lvtgt),:lvsrcposition)
 # return argument position of source sum dynamical variable of an auxiliary variable
-lsvvposition(p::AbstractStockAndFlowF,v) = subpart(p,incident(p,v,:lsvv),:lsvsvposition) 
+lsvvposition(p::AbstractStockAndFlowF,v) = subpart(p,incident(p,v,:lsvv),:lsvsvposition)
 # return argument position of source constant parameter of an auxiliary variable
-lpvvposition(p::AbstractStockAndFlowF,v) = subpart(p,incident(p,v,:lpvv),:lpvpposition) 
+lpvvposition(p::AbstractStockAndFlowF,v) = subpart(p,incident(p,v,:lpvv),:lpvpposition)
 
 # create a dictionary
 make_dict(ks, vs) = begin
@@ -637,7 +637,7 @@ function make_v_expr(p::AbstractStockAndFlowF,v)
     srcsvv=map(i->svname(p,i),svsv(p,v))
     srcpv=map(i->pname(p,i),vpsrc(p,v))
     srcvv=map(i->vname(p,i),vsrc(p,v))
-       
+
     lvvp=lvvposition(p,v)
     lvtgtp=lvtgtposition(p,v)
     lsvvp=lsvvposition(p,v)
@@ -648,10 +648,10 @@ function make_v_expr(p::AbstractStockAndFlowF,v)
     end
 
     # create dictionary of (key=position, value=symbole of source argument)
-    position_src=merge(make_dict(lvvp,srcsv),make_dict(lsvvp,srcsvv),make_dict(lpvvp,srcpv),make_dict(lvtgtp,srcvv))    
-    ordered_position_src=sort(collect(position_src), by = x->x[1])    
+    position_src=merge(make_dict(lvvp,srcsv),make_dict(lsvvp,srcsvv),make_dict(lpvvp,srcpv),make_dict(lvtgtp,srcvv))
+    ordered_position_src=sort(collect(position_src), by = x->x[1])
     srcs=map(x->last(x),ordered_position_src)
-    
+
     return math_expr(op,srcs...)
 end
 # genreate an array of all arguments of an expression
@@ -695,17 +695,17 @@ funcDynam(p::AbstractStockAndFlow,v) = subpart(p,v,:funcDynam)
 funcDynam(sf::AbstractStockAndFlowF,v) = begin
     expr=make_v_expr(sf,v)
     args=generate_expr_args(expr)
-    
+
     args_s=args[findall(in(snames(sf)),args)]
     args_sv=args[findall(in(svnames(sf)),args)]
     args_p=args[findall(in(pnames(sf)),args)]
-    
+
     f(u,uN,p,t)=begin
         us=map(i->u[i],args_s)
         uNs=map(i->uN[i](u,t),args_sv)
         ps=map(i->p[i],args_p)
-        return eval_function(expr,args_s,args_sv,args_p,us,uNs,ps)     
-    end    
+        return eval_function(expr,args_s,args_sv,args_p,us,uNs,ps)
+    end
     return f
 end
 
@@ -740,11 +740,11 @@ funcSV(p::AbstractStockAndFlow0,sv) = begin
         for i in stockssv(p,sv)
             sumS=sumS+u[sname(p,i)]
         end
-        return sumS        
+        return sumS
     end
-    return uN       
+    return uN
 end
-# return the LVector of pairs: svname => function 
+# return the LVector of pairs: svname => function
 funcSVs(p::AbstractStockAndFlow0) = begin
   svnames = [svname(p, sv) for sv in 1:nsv(p)]
   LVector(;[(svnames[sv]=>funcSV(p, sv)) for sv in 1:nsv(p)]...)
@@ -801,22 +801,22 @@ end
 Open(p::StockAndFlow, feet...) = begin
   legs = map(x->leg(x, p), feet)
   OpenStockAndFlow{Symbol,Function}(p, legs...)
-end 
+end
 
 Open(p::StockAndFlowF, feet...) = begin
   legs = map(x->leg(x, p), feet)
   OpenStockAndFlowF{Symbol,Symbol,Int8}(p, legs...)
-end 
+end
 
 Open(p::StockAndFlowStructure, feet...) = begin
   legs = map(x->leg(x, p), feet)
   OpenStockAndFlowStructure{Symbol}(p, legs...)
-end 
+end
 
 
 ############# functions of generating ODEs ###############
 
-struct TransitionMatrices 
+struct TransitionMatrices
 # row represent flows, column represent stocks; and element of 1 of matrix indicates whether there is a connection between the flow and stock; 0 indicates no connection
   inflow::Matrix{Int}
   outflow::Matrix{Int}
@@ -840,7 +840,7 @@ valueat(f::Function, u, uN, p, t)=f(u,uN,p,t)
 
 # test argumenterror -- stocks in function of flow "fn" are not linked!
 # TODO: find method to generate the exact wrong stocks' names and output in error message
-ftest(f::Function, u, p, fn) = 
+ftest(f::Function, u, p, fn) =
 try
   f(u,p,0)
 catch e
@@ -857,7 +857,7 @@ ferror(f::Function, u, p, fn, umissed) = begin
 end
 
 # test stocks in function of flow "fn" are missed!
-fmisstest(f::Function, u, p, fn, umissed) = 
+fmisstest(f::Function, u, p, fn, umissed) =
 try
   ferror(f,u,p,fn, umissed)
 catch e
@@ -919,47 +919,4 @@ include("SystemStructure.jl")
 include("visualization.jl")
 # The implementations in this file is specific for the Primitive schema of stock and flow diagram in the ACT paper
 include("PrimitiveStockFlowInPaper.jl")
-
 end
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/test/Syntax.jl
+++ b/test/Syntax.jl
@@ -1,3 +1,4 @@
+using Base: is_unary_and_binary_operator
 using Test
 using StockFlow
 using StockFlow.Syntax
@@ -6,6 +7,7 @@ using StockFlow.Syntax: is_binop_or_unary, sum_variables, infix_expression_to_bi
 @testset "is_binop_or_unary recognises binops" begin
     @test is_binop_or_unary(:(a + b))
     @test is_binop_or_unary(:(f(a, b)))
+    @test is_binop_or_unary(:(1.0 + x))
 end
 @testset "is_binop_or_unary recognises non-binops as non-binops" begin
     @test !is_binop_or_unary(:(f()))
@@ -59,6 +61,23 @@ end
     # Multiparameter flows
     @test_throws Exception extract_function_name_and_args_expr(:(testf(a, b)))
 end
+
+#@testset "non-variable parameters in functions" begin
+#  @stock_and_flow begin
+#      :stocks
+#       A
+#       B
+#       C
+#       :parameters
+#       x
+#       y
+#       z
+#       :dynamic_variables
+# TODO? f = 1.0 - x
+#       :flows
+#       A => fname(f) => B
+#  end
+#end
 
 @testset "model allows uses unary functions like log" begin
     SIR_1_via_macro = @stock_and_flow begin

--- a/test/Syntax.jl
+++ b/test/Syntax.jl
@@ -1,0 +1,226 @@
+using Test
+using StockFlow
+using StockFlow.Syntax
+using StockFlow.Syntax: is_binop_or_unary, sum_variables, infix_expression_to_binops, fnone_value_or_vector, extract_function_name_and_args_expr
+
+@testset "is_binop_or_unary recognises binops" begin
+    @test is_binop_or_unary(:(a + b))
+    @test is_binop_or_unary(:(f(a, b)))
+end
+@testset "is_binop_or_unary recognises non-binops as non-binops" begin
+    @test !is_binop_or_unary(:(f()))
+    @test !is_binop_or_unary(:(a + b + c))
+    @test !is_binop_or_unary(:(f(a, b, c)))
+end
+
+@testset "sum_variables" begin
+    @test sum_variables([]) == []
+    @test sum_variables([(:a, 1)]) == [:a]
+    @test sum_variables([(:a, 1), (:b, 2)]) == [:a, :b]
+end
+
+@testset "infix_expression_to_binops does nothing to binops and unary exprs" begin
+    @test infix_expression_to_binops(:(f(a)))[1][1][2] == :(f(a))
+    @test infix_expression_to_binops(:(f(a, b)))[1][1][2] == :(f(a, b))
+    @test infix_expression_to_binops(:(a + b))[1][1][2] == :(a + b)
+end
+
+@testset "infix_expression_to_binops creates right number of expressions" begin
+    @test length(infix_expression_to_binops(:(a + b + c))[1]) == 2
+    @test length(infix_expression_to_binops(:(a + b + c + d))[1]) == 3
+    @test length(infix_expression_to_binops(:(a + b + c + d + e))[1]) == 4
+    @test length(infix_expression_to_binops(:(a + b + c + d + e + f))[1]) == 5
+end
+
+@testset "infix_expression_to_binops throws exception when no binops provided" begin
+    @test_throws Exception infix_expression_to_binops(:(f()))
+end
+
+@testset "infix_expression_to_binops uses final symbol" begin
+    @test infix_expression_to_binops(:(f(a, b)); finalsym=:testsym)[2] == :testsym
+    @test infix_expression_to_binops(:(a + b); finalsym=:testsym)[2] == :testsym
+end
+
+@testset "fnone_value_or_vector" begin
+    empty_symbol_vector::Vector{Symbol} = []
+    @test fnone_value_or_vector(empty_symbol_vector) == :F_NONE
+    @test fnone_value_or_vector([:a]) == :a
+    @test fnone_value_or_vector([:a, :b]) == [:a, :b]
+end
+
+@testset "extract_function_name_args_expr extracts the flow name and flow definition" begin
+    @test extract_function_name_and_args_expr(:(testf(a))) == (:testf, :a)
+    @test extract_function_name_and_args_expr(:(testf(a + b + c + d))) == (:testf, :(a + b + c + d))
+end
+
+@testset "extract_function_name_args_expr rejects invalid flow expressions" begin
+    # Undefined flow equation
+    @test_throws Exception extract_function_name_and_args_expr(:(testf()))
+    # Multiparameter flows
+    @test_throws Exception extract_function_name_and_args_expr(:(testf(a, b)))
+end
+
+@testset "model allows uses unary functions like log" begin
+    SIR_1_via_macro = @stock_and_flow begin
+        :stocks
+        S
+        I
+        R
+
+        :parameters
+        c
+        beta
+        tRec
+
+        :dynamic_variables
+        v_prevalence = exp(I)
+        v_meanInfectiousContactsPerS = c * v_prevalence
+        v_perSIncidenceRate = beta * v_meanInfectiousContactsPerS
+        v_newInfections = S * v_perSIncidenceRate
+        v_newRecovery = log(I)
+
+        :flows
+        S => inf(v_newInfections) => I
+        I => rec(v_newRecovery) => R
+
+        :sums
+        N = [S, I, R]
+    end
+
+    SIR_1_canonical = StockAndFlowF(
+        # stocks
+        (:S => (:F_NONE, :inf, :N), :I => (:inf, :rec, :N), :R => (:rec, :F_NONE, :N)),
+        # parameters
+        (:c, :beta, :tRec),
+        # dynamical variables
+        (:v_prevalence => (:I => :exp),
+            :v_meanInfectiousContactsPerS => ((:c, :v_prevalence) => :*),
+            :v_perSIncidenceRate => ((:beta, :v_meanInfectiousContactsPerS) => :*),
+            :v_newInfections => ((:S, :v_perSIncidenceRate) => :*),
+            :v_newRecovery => (:I => :log),
+        ),
+        # flows
+        (:inf => :v_newInfections, :rec => :v_newRecovery),
+        # sum dynamical variables
+        (:N),
+    )
+    @test SIR_1_via_macro == SIR_1_canonical
+end
+@testset "stock_and_flow macro generates the expected StockAndFlowF representations" begin
+    SIR_1_via_macro = @stock_and_flow begin
+        :stocks
+        S
+        I
+        R
+
+        :parameters
+        c
+        beta
+        tRec
+
+        :dynamic_variables
+        v_prevalence = I / N
+        v_meanInfectiousContactsPerS = c * v_prevalence
+        v_perSIncidenceRate = beta * v_meanInfectiousContactsPerS
+        v_newInfections = S * v_perSIncidenceRate
+        v_newRecovery = I / tRec
+
+        :flows
+        S => inf(v_newInfections) => I
+        I => rec(v_newRecovery) => R
+
+        :sums
+        N = [S, I, R]
+    end
+
+    SIR_1_canonical = StockAndFlowF(
+        # stocks
+        (:S => (:F_NONE, :inf, :N), :I => (:inf, :rec, :N), :R => (:rec, :F_NONE, :N)),
+        # parameters
+        (:c, :beta, :tRec),
+        # dynamical variables
+        (:v_prevalence => ((:I, :N) => :/),
+            :v_meanInfectiousContactsPerS => ((:c, :v_prevalence) => :*),
+            :v_perSIncidenceRate => ((:beta, :v_meanInfectiousContactsPerS) => :*),
+            :v_newInfections => ((:S, :v_perSIncidenceRate) => :*),
+            :v_newRecovery => ((:I, :tRec) => :/),
+        ),
+        # flows
+        (:inf => :v_newInfections, :rec => :v_newRecovery),
+        # sum dynamical variables
+        (:N),
+    )
+    @test SIR_1_via_macro == SIR_1_canonical
+
+    SIR_2 = @stock_and_flow begin
+        :stocks
+        S
+        I
+        R
+
+        :parameters
+        c
+        beta
+        tRec
+
+        # We can leave out dynamic variables and let them be inferred from flows entirely!
+
+        :flows
+        S => inf(S * beta * (c * (I / N))) => I
+        I => rec(I / tRec) => R
+
+        :sums
+        N = [S, I, R]
+    end
+
+    # Although the variable names are different
+    # due to gensym, the models should structurally be the same.
+    for part in SIR_2.parts
+        @test SIR_2.parts[part] == SIR_1_canonical.parts[part]
+    end
+end
+
+@testset "stock_and_flow macro base cases" begin
+    empty_via_macro = @stock_and_flow begin end
+    @test empty_via_macro == StockAndFlowF()
+
+    no_sums = @stock_and_flow begin
+        :stocks
+        A
+        B
+        C
+
+        :parameters
+        p
+        q
+
+        :dynamic_variables
+        dyvar1 = A + B
+        dyvar2 = B * C
+        dyvar3 = sqrt(q)
+        dyvar4 = exp(p)
+        dyvar5 = log(dyvar3, dyvar4)
+
+        :flows
+        A => f1(dyvar1) => B
+        B => f2(dyvar2) => C
+        C => f3(dyvar5) => A
+    end
+    no_sums_canonical = StockAndFlowF(
+        #stocks
+        (:A => (:f3, :f1, :SV_NONE), :B => (:f1, :f2, :SV_NONE), :C => (:f2, :f3, :SV_NONE)),
+        #params
+        (:p, :q),
+        # dyvars
+        (:dyvar1 => ((:A, :B) => :+),
+         :dyvar2 => ((:B, :C) => :*),
+         :dyvar3 => (:q => :sqrt),
+         :dyvar4 => (:p => :exp),
+         :dyvar5 => ((:dyvar3, :dyvar4) => :log)),
+        #flows
+        (:f1 => :dyvar1,
+         :f2 => :dyvar2,
+         :f3 => :dyvar5),
+        ())
+    @test no_sums == no_sums_canonical
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
-using StockFlow
 using Test
+using StockFlow
 
-@testset "AlgebraicStockFlow.jl" begin
-    @test true
+@testset "StockFlow DSL" begin
+    include("Syntax.jl")
 end


### PR DESCRIPTION
### Description

Add tests of the Stock & Flow domain-specific language and fix any bugs revealed

### Additional fixes

- Allows unary functions like `sqrt` and `exp` in dynamic variable generation and flows
- Fixes no sum variables to use `:SV_NONE`
- Constants are allowed in the DSL and passed to `StockAndFlowF`, but `StockAndFlowF` does not appear to support them. E.g.
    - `dyvarname = 1.0 - x`
- Recursive dynamic variables, e.g. `v = v + v`, are rejected.

### NOTE

Re-opened as a clean commit for a cleaner git history, due to divergences between this branch and master. Similar to the reason that #16 was closed in favour of #20 -- #28 continued from #16; this continues from #20

fyi @Xiaoyan-Li 