### PR TITLE
using Catlab.Present -> using Catlab.Presentations

### DIFF
--- a/src/StockFlow.jl
+++ b/src/StockFlow.jl
@@ -14,7 +14,7 @@ vop, lvvposition, lvtgtposition, lsvvposition, lpvvposition, recreate_stratified
 using Catlab
 using Catlab.CategoricalAlgebra
 using Catlab.CategoricalAlgebra.FinSets
-using Catlab.Present
+using Catlab.Presentations
 using Catlab.Theories
 using LabelledArrays
 using LinearAlgebra: mul!


### PR DESCRIPTION
Fixing an issue with new version of Catlab having @present defined in Presentation.  May still error if Syntax.jl uses the installed StockFlow.jl, rather than this one (the other pull request should fix that)