### PR TITLE
Syntax.jl now imports ..StockFlow (the parent, if StockFlow is includ…

### DIFF
--- a/src/Syntax.jl
+++ b/src/Syntax.jl
@@ -105,7 +105,7 @@ end
 module Syntax
 export @stock_and_flow, @foot, @feet
 
-using StockFlow
+using ..StockFlow
 using MLStyle
 
 """


### PR DESCRIPTION
…ing it) rather than StockFlow on its own (this means it won't be able to run on its own, but it will use the definitions from the parent StockFlow, rather than whatever StockFlow you have installed)