### PR TITLE
Some obvious fixes for prefixes/suffixes and tests.  Fixed a typo in …

### DIFF
--- a/src/SystemStructure.jl
+++ b/src/SystemStructure.jl
@@ -2,8 +2,6 @@ export convertStockFlowToSystemStructure, convertSystemStructureToStockFlow, reb
 extracStocksStructureAndFlatten,extracFlowsStructureAndFlatten,extracSumVStructureAndFlatten,extracVStructureAndFlatten,extracPsStructureAndFlatten,
 extracVAndAttrStructureAndFlatten, extracVStructureAndFlatten, args_vname, args, add_prefix!, add_suffix!
 
-using Catlab.CategoricalAlgebra.StructuredCospans
-
 flattenTupleNames(sn::Tuple)=Symbol(foldr(string,map(x->string(x), sn)))
 flattenTupleNames(sn::Symbol)=sn
 flattenTupleNames(sn::SubArray{Symbol})=sn
@@ -306,7 +304,7 @@ end
 Modify a AbstractStockAndFlow0 so named elements begin with prefix.
 For feet.
 """
-function add_prefix!(sf::AbstractStockAndFlow0, suffix)
+function add_prefix!(sf::AbstractStockAndFlow0, prefix)
     prefix = Symbol(prefix)
     set_snames!(sf, prefix .++ snames(sf))
     set_svnames!(sf, prefix .++ svnames(sf))

--- a/test/SystemStructure.jl
+++ b/test/SystemStructure.jl
@@ -1,10 +1,6 @@
 using Test
 using StockFlow
 using StockFlow.Syntax
-import Base.deepcopy
-using Catlab.CategoricalAlgebra.StructuredCospans
-
-
 
 empty = @stock_and_flow begin end
 
@@ -68,15 +64,11 @@ p_suffixed = @stock_and_flow begin
     NIsuf = [Isuf]
 end
 
-empty_foot = foot((),(),())
+empty_foot = @foot () => ()
 
-footA = foot(:S, :N, :S => :N)
-footA_pref = foot(:prefS, :prefN, :prefS => :prefN)
-footA_suf = foot(:Ssuf, :Nsuf, :Ssuf => :Nsuf)
-
-footB = foot(:prefI, :prefNI, :prefI => :prefNI)
-
-
+footA = @foot S => N
+footA_pref = @foot prefS => prefN
+footA_suf = @foot Ssuf => Nsuf
 
 
 @testset "changing names act the same as if the stock flow/foot/open was created with the changed name" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,3 +4,7 @@ using StockFlow
 @testset "StockFlow DSL" begin
     include("Syntax.jl")
 end
+
+@testset "Attribute names prefixes and suffixes" begin
+    include("SystemStructure.jl")
+end


### PR DESCRIPTION
…a set_prefix function which used 'suffix' as a parameter and thus didn't work.  Rewrote tests to use the new @foot syntax, and included them in the runtest.jl file.