### PR TITLE
Created simple documentation by following the template from Catlab to compile docstrings

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+build/
+src/generated/

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,59 @@
+using Documenter
+using Literate
+
+const literate_dir = joinpath(@__DIR__, "literate")
+const generated_dir = joinpath(@__DIR__, "src", "generated")
+
+@info "Loading StockFlow.jl"
+using StockFlow
+
+const no_literate = "--no-literate" in ARGS
+if !no_literate
+  @info "Building Literate.jl docs"
+
+  # XXX: Work around old LaTeX distribution in GitHub CI.
+  if haskey(ENV, "GITHUB_ACTIONS")
+    import TikzPictures
+    TikzPictures.standaloneWorkaround(true)
+  end
+
+  # Set Literate.jl config if not being compiled on recognized service.
+  config = Dict{String,String}()
+  if !(haskey(ENV, "GITHUB_ACTIONS") || haskey(ENV, "GITLAB_CI"))
+    config["nbviewer_root_url"] = "https://nbviewer.jupyter.org/github/AlgebraicJulia/StockFlow.jl/blob/gh-pages/dev"
+    config["repo_root_url"] = "https://github.com/AlgebraicJulia/StockFlow.jl/blob/main/docs"
+  end
+
+  for (root, dirs, files) in walkdir(literate_dir)
+    out_dir = joinpath(generated_dir, relpath(root, literate_dir))
+    for file in files
+      if last(splitext(file)) == ".jl"
+        Literate.markdown(joinpath(root, file), out_dir;
+                          config=config, documenter=true, credit=false)
+        Literate.notebook(joinpath(root, file), out_dir;
+                          execute=true, documenter=true, credit=false)
+      end
+    end
+  end
+end
+
+@info "Building Documenter.jl docs"
+makedocs(
+  modules     = [StockFlow],
+  format      = Documenter.HTML(
+                                assets = ["assets/analytics.js"],
+                               ),
+  sitename    = "StockFlow.jl",
+  doctest     = false,
+  checkdocs   = :none,
+  pages       = Any[
+    "StockFlow.jl" => "index.md",
+  ]
+)
+
+@info "Deploying docs"
+deploydocs(
+  target = "build",
+  repo   = "github.com/AlgebraicJulia/StockFlow.jl.git",
+  branch = "gh-pages"
+)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -48,6 +48,10 @@ makedocs(
   checkdocs   = :none,
   pages       = Any[
     "StockFlow.jl" => "index.md",
+    "Modules" => Any[
+      "apis/Syntax.md",
+      "apis/PremadeModels.md"
+    ]
   ]
 )
 

--- a/docs/src/apis/PremadeModels.md
+++ b/docs/src/apis/PremadeModels.md
@@ -1,0 +1,8 @@
+# [PremadeModels](@id PremadeModels)
+
+```@autodocs
+Modules = [
+    StockFlow.PremadeModels
+]
+Private = false
+```

--- a/docs/src/apis/Syntax.md
+++ b/docs/src/apis/Syntax.md
@@ -1,8 +1,8 @@
-# [StockFlow](@id StockFlow)
+# [Syntax](@id Syntax)
 
 ```@autodocs
 Modules = [
-    StockFlow
+    StockFlow.Syntax
 ]
 Private = false
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,10 @@
+# [StockFlow](@id StockFlow)
+
+```@autodocs
+Modules = [
+    StockFlow,
+    StockFlow.Syntax,
+    StockFlow.PremadeModels
+]
+Private = false
+```


### PR DESCRIPTION
We need more docstrings.

Run make.jl to generate the site.

I think it can be deployed on github.io similar to how Catlab does it.

![image](https://github.com/AlgebraicJulia/StockFlow.jl/assets/61016353/57bfaf2d-ce6c-467e-9d07-17f0d3be9bc1)
![image](https://github.com/AlgebraicJulia/StockFlow.jl/assets/61016353/6413d7a0-4fbf-4a9c-9556-2386ee0aaec4)

