### PR TITLE
Style adherence

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+build/
+src/generated/

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,59 @@
+using Documenter
+using Literate
+
+const literate_dir = joinpath(@__DIR__, "literate")
+const generated_dir = joinpath(@__DIR__, "src", "generated")
+
+@info "Loading StockFlow.jl"
+using StockFlow
+
+const no_literate = "--no-literate" in ARGS
+if !no_literate
+  @info "Building Literate.jl docs"
+
+  # XXX: Work around old LaTeX distribution in GitHub CI.
+  if haskey(ENV, "GITHUB_ACTIONS")
+    import TikzPictures
+    TikzPictures.standaloneWorkaround(true)
+  end
+
+  # Set Literate.jl config if not being compiled on recognized service.
+  config = Dict{String,String}()
+  if !(haskey(ENV, "GITHUB_ACTIONS") || haskey(ENV, "GITLAB_CI"))
+    config["nbviewer_root_url"] = "https://nbviewer.jupyter.org/github/AlgebraicJulia/StockFlow.jl/blob/gh-pages/dev"
+    config["repo_root_url"] = "https://github.com/AlgebraicJulia/StockFlow.jl/blob/main/docs"
+  end
+
+  for (root, dirs, files) in walkdir(literate_dir)
+    out_dir = joinpath(generated_dir, relpath(root, literate_dir))
+    for file in files
+      if last(splitext(file)) == ".jl"
+        Literate.markdown(joinpath(root, file), out_dir;
+                          config=config, documenter=true, credit=false)
+        Literate.notebook(joinpath(root, file), out_dir;
+                          execute=true, documenter=true, credit=false)
+      end
+    end
+  end
+end
+
+@info "Building Documenter.jl docs"
+makedocs(
+  modules     = [StockFlow],
+  format      = Documenter.HTML(
+                                assets = ["assets/analytics.js"],
+                               ),
+  sitename    = "StockFlow.jl",
+  doctest     = false,
+  checkdocs   = :none,
+  pages       = Any[
+    "StockFlow.jl" => "index.md",
+  ]
+)
+
+@info "Deploying docs"
+deploydocs(
+  target = "build",
+  repo   = "github.com/AlgebraicJulia/StockFlow.jl.git",
+  branch = "gh-pages"
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,10 @@
+# [StockFlow](@id StockFlow)
+
+```@autodocs
+Modules = [
+    StockFlow,
+    StockFlow.Syntax,
+    StockFlow.PremadeModels
+]
+Private = false
+```

--- a/src/CausalLoop.jl
+++ b/src/CausalLoop.jl
@@ -2,7 +2,6 @@ export TheoryCausalLoop, AbstractCausalLoop, CausalLoopUntyped, CausalLoop, nn, 
 sedge, tedge, convertToCausalLoop, nnames
 
 
-
 @present TheoryCausalLoop(FreeSchema) begin
   E::Ob
   N::Ob
@@ -26,6 +25,10 @@ add_nodes!(c::AbstractCausalLoop,n;kw...) = add_parts!(c,:N,n;kw...)
 add_edge!(c::AbstractCausalLoop,s,t;kw...) = add_part!(c,:E,s=s,t=t;kw...) 
 add_edges!(c::AbstractCausalLoop,n,s,t;kw...) = add_parts!(c,:E,n,s=s,t=t;kw...)
 
+"""
+    CausalLoop(ns,es)
+Create causal loop diagram from collection of nodes and collection of edges.
+"""
 CausalLoop(ns,es) = begin
     c = CausalLoop()
     ns = vectorify(ns)
@@ -42,14 +45,21 @@ CausalLoop(ns,es) = begin
 end
 
 # return the count of each components
+""" return count of nodes of CLD """
 nn(c::AbstractCausalLoop) = nparts(c,:N) #nodes
+""" return count of edges of CLD """
 ne(c::AbstractCausalLoop) = nparts(c,:E) #edges
 
+""" return node's name with index n """
 nname(c::AbstractCausalLoop,n) = subpart(c,n,:nname) # return the node's name with index of s
+""" return edge's name with target number t """
 sedge(c::AbstractCausalLoop,e) = subpart(c,e,:s)
+""" return edge's name with edge number e """
 tedge(c::AbstractCausalLoop,e) = subpart(c,e,:t)
 
+""" return node names of CLD """
 nnames(c::AbstractCausalLoop) = [nname(c, n) for n in 1:nn(c)]
+
 
 function convertToCausalLoop(p::AbstractStockAndFlowStructure)
     
@@ -73,6 +83,11 @@ function convertToCausalLoop(p::AbstractStockAndFlowStructure)
     return CausalLoop(ns,es)
 end
 
+"""
+Convert StockFlow to CLD.
+Nodes: stocks, flows, sum variables, parameters, nonflow dynamic variables
+Edges: morphisms in stock flow
+"""
 function convertToCausalLoop(p::AbstractStockAndFlowStructureF)
     
     sns=snames(p)

--- a/src/PremadeModels.jl
+++ b/src/PremadeModels.jl
@@ -4,18 +4,30 @@ using ..StockFlow.Syntax
 
 export seir, sis, sir, svi
 
+"""
+Return a new SEIR model
+"""
 function seir()
     return deepcopy(seir_model)
 end
 
+"""
+Return a new SIS model
+"""
 function sis()
     return deepcopy(sis_model)
 end
 
+"""
+Return a new SIR model
+"""
 function sir()
     return deepcopy(sir_model)
 end
 
+"""
+Return a new SVI model
+"""
 function svi()
     return deepcopy(svi_model)
 end

--- a/src/StockFlow.jl
+++ b/src/StockFlow.jl
@@ -4,7 +4,7 @@ export TheoryStockAndFlow0, TheoryStockAndFlow, TheoryStockAndFlowStructure, The
 AbstractStockAndFlowStructureF, AbstractStockAndFlowF, StockAndFlow0, StockAndFlow, StockAndFlowStructure, StockAndFlowStructureF, StockAndFlowF, add_flow!, add_flows!, add_stock!, add_stocks!,
 add_variable!, add_variables!, add_svariable!, add_svariables!, add_parameter!, add_parameters!, add_VVlink!, add_VVlinks!,
 add_inflow!, add_inflows!, add_outflow!, add_outflows!, add_Vlink!, add_Vlinks!, add_Slink!, add_Slinks!, add_SVlink!, add_Plink!, add_Plinks!,
-add_SVlinks!, ns, nf, ni, no, nvb, nsv, nls, nlv, nlsv, np, nlpv,nlvv,sname, fname, svname, svnames, vname, inflows, outflows, svStocks,
+add_SVlinks!, ns, nf, ni, no, nvb, nsv, nls, nlv, nlsv, np, nlpv, nlvv, sname, fname, svname, svnames, vname, inflows, outflows,
 funcDynam, flowVariableIndex, funcFlow, funcFlows, funcSV, funcSVs, TransitionMatrices,
 vectorfield, funcFlowsRaw, funcFlowRaw, inflowsAll, outflowsAll,instock,outstock, stockssv, stocksv, svsv, svsstock,
 vsstock, vssv, svsstockAllF, vsstockAllF, vssvAllF, StockAndFlowUntyped, StockAndFlowFUntyped, StockAndFlowStructureUntyped, StockAndFlowStructureFUntyped, StockAndFlowUntyped0, Open, snames, fnames, svnames, vnames,
@@ -70,7 +70,7 @@ math_expr(op, op1) = Expr(:call, op, op1)
 #math_expr(op) = Expr(:call, op)
 
 
-# define the sub-schema of c0, which includes the three objects: stocks(S), sum-auxiliary-variables(SV), and the linkages between them (LS) to be composed
+""" define the sub-schema of c0, which includes the three objects: stocks(S), sum-auxiliary-variables(SV), and the linkages between them (LS) to be composed """
 @present TheoryStockAndFlow0(FreeSchema) begin
   S::Ob
   SV::Ob
@@ -92,8 +92,11 @@ end
 # 2. Name: Symbol
 const StockAndFlow0 = StockAndFlowUntyped0{Symbol}
 
-# for an instance of the sub-schema, the program supports only have stocks, or only have sum auxiliary variables, or both stocks
-# and sum auxiliary variables, or have both
+"""
+    StockAndFlow0(s,sv,ssv)
+    
+for an instance of the sub-schema, the program supports only have stocks, or only have sum auxiliary variables, or both stocks
+ and sum auxiliary variables, or have both """
 StockAndFlow0(s,sv,ssv) = begin
   p0 = StockAndFlow0()
   s = vectorify(s)
@@ -118,7 +121,7 @@ StockAndFlow0(s,sv,ssv) = begin
   p0
 end
 
-# define the schema of a general stock and flow diagram, not includes the functions of auxiliary variables
+""" define the schema of a general stock and flow diagram, not includes the functions of auxiliary variables """
 @present TheoryStockAndFlowStructure <: TheoryStockAndFlow0 begin
   F::Ob
   I::Ob
@@ -167,7 +170,7 @@ end
 const StockAndFlow = StockAndFlowUntyped{Symbol,Function}
 
 
-# define the schema of a general stock and flow diagram
+""" define the schema of a general stock and flow diagram """
 @present TheoryStockAndFlowStructureF <: TheoryStockAndFlowStructure begin
 #Objects
   P::Ob
@@ -188,7 +191,7 @@ end
 const StockAndFlowStructureF = StockAndFlowStructureFUntyped{Symbol}
 
 
-# define the schema of a general stock and flow diagram
+""" define the schema of a general stock and flow diagram """
 @present TheoryStockAndFlowF <: TheoryStockAndFlowStructureF begin
 
 # Attributes:
@@ -239,18 +242,33 @@ add_SVlink!(p::AbstractStockAndFlowStructure,sv,v;kw...) = add_part!(p,:LSV;lsvs
 add_SVlinks!(p::AbstractStockAndFlowStructure,n,sv,v;kw...) = add_parts!(p,:LSV,n;lsvsv=sv,lsvv=v,kw...)
 
 # return the count of each components
+""" stock count """
 ns(p::AbstractStockAndFlow0) = nparts(p,:S) #stocks
+""" flow count """
 nf(p::AbstractStockAndFlowStructure) = nparts(p,:F) #flows
+""" inflow count """
 ni(p::AbstractStockAndFlowStructure) = nparts(p,:I) #inflows
+""" outflow count """
 no(p::AbstractStockAndFlowStructure) = nparts(p,:O) #outflows
+""" dynamic variable count """
 nvb(p::AbstractStockAndFlowStructure) = nparts(p,:V) #auxiliary variables
+""" sum variable count """
 nsv(p::AbstractStockAndFlow0) = nparts(p,:SV) #sum auxiliary variables
+""" link stock sum count """
 nls(p::AbstractStockAndFlow0) = nparts(p,:LS) #links from Stock to sum dynamic variable
+""" link stock dynamic variable count """
 nlv(p::AbstractStockAndFlowStructure) = nparts(p,:LV) #links from Stock to dynamic variable
-nlsv(p::AbstractStockAndFlowStructure) = nparts(p,:LSV) #links from sum dynamic variable to dynamic varibale
-nlvv(p::AbstractStockAndFlowStructureF) = nparts(p,:LVV) #links from dynamic variable to dynamic varibale
-nlpv(p::AbstractStockAndFlowStructureF) = nparts(p,:LPV) #links from dynamic variable to dynamic varibale
+""" link sum variable dynamic variable count """
+nlsv(p::AbstractStockAndFlowStructure) = nparts(p,:LSV) #links from sum dynamic variable to dynamic variable
+""" link dynamic variable dynamic variable count """
+nlvv(p::AbstractStockAndFlowStructureF) = nparts(p,:LVV) #links from dynamic variable to dynamic variable
+""" link dynamic variable parameter count """
+nlpv(p::AbstractStockAndFlowStructureF) = nparts(p,:LPV) #links from dynamic variable to parameters
+""" parameter count """
 np(p::AbstractStockAndFlowStructureF) = nparts(p,:P) #parameters
+
+
+
 
 #EXAMPLE:
 #sir_StockAndFlow=StockAndFlow(((:S, 990)=>(:birth,(:inf,:deathS),(:v_inf,:v_deathS),:N), (:I, 10)=>(:inf,(:rec,:deathI),(:v_rec,:v_deathI,:v_fractionNonS),:N),(:R, 0)=>(:rec,:deathR,(:v_deathR,:v_fractionNonS),:N)),
@@ -470,14 +488,18 @@ StockAndFlowStructureF(s,p,v,f,sv) = begin
   sf
 end
 
+"""
+    StockAndFlowF(s,p,v,f,sv)
 
-#EXAMPLE: when define the dynamical variables, need to define with the correct order
-#sir_StockAndFlow=StockAndFlowF((:S=>(:F_NONE,:inf,:N), :I=>(:inf,:F_NONE,:N)),
-#  (:c, :beta),
-#  (:v_prevalence=>(:I,:N,:/),:v_meanInfectiousContactsPerS=>(:c,:v_prevalence,:*),:v_perSIncidenceRate=>(:beta,:v_meanInfectiousContactsPerS,:*),:v_newInfetions=>(:S,:v_perSIncidenceRate,:*)),
-#  (:inf=>:v_newInfetions),
-#  (:N))
-
+EXAMPLE: when define the dynamical variables, need to define with the correct order
+```julia
+sir_StockAndFlow=StockAndFlowF((:S=>(:F_NONE,:inf,:N), :I=>(:inf,:F_NONE,:N)),
+ (:c, :beta),
+ (:v_prevalence=>(:I,:N,:/),:v_meanInfectiousContactsPerS=>(:c,:v_prevalence,:*),:v_perSIncidenceRate=>(:beta,:v_meanInfectiousContactsPerS,:*),:v_newInfetions=>(:S,:v_perSIncidenceRate,:*)),
+ (:inf=>:v_newInfetions),
+ (:N))
+```
+"""
 StockAndFlowF(s,p,v,f,sv) = begin
   sf = StockAndFlowF()
 
@@ -550,22 +572,37 @@ StockAndFlowF(s,p,v,f,sv) = begin
   sf
 end
 
-sname(p::AbstractStockAndFlow0,s) = subpart(p,s,:sname) # return the stocks name with index of s
-fname(p::AbstractStockAndFlowStructure,f) = subpart(p,f,:fname) # return the flows name with index of f
-svname(p::AbstractStockAndFlow0,sv) = subpart(p,sv,:svname) # return the sum auxiliary variables name with index of sv
-vname(p::AbstractStockAndFlowStructure,v) = subpart(p,v,:vname) # return the auxiliary variables name with index of v
-pname(sf::AbstractStockAndFlowStructureF,p) = subpart(sf,p,:pname) # return the auxiliary variables name with index of v
+""" return the stocks name with index of s """
+sname(p::AbstractStockAndFlow0,s) = subpart(p,s,:sname) 
+""" return the flows name with index of f """
+fname(p::AbstractStockAndFlowStructure,f) = subpart(p,f,:fname)
+""" return the sum auxiliary variables name with index of sv """
+svname(p::AbstractStockAndFlow0,sv) = subpart(p,sv,:svname) 
+""" return the auxiliary variables name with index of v """
+vname(p::AbstractStockAndFlowStructure,v) = subpart(p,v,:vname) 
+""" return the auxiliary variables name with index of v """
+pname(sf::AbstractStockAndFlowStructureF,p) = subpart(sf,p,:pname)
 
+""" return stock names """
 snames(p::AbstractStockAndFlow0) = [sname(p, s) for s in 1:ns(p)]
+""" return flow names """
 fnames(p::AbstractStockAndFlowStructure) = [fname(p, f) for f in 1:nf(p)]
+""" return sum variable names """
 svnames(p::AbstractStockAndFlow0) = [svname(p, sv) for sv in 1:nsv(p)]
+""" return variable names """ 
 vnames(p::AbstractStockAndFlowStructure) = [vname(p, v) for v in 1:nvb(p)]
+""" return parameter names """
 pnames(sf::AbstractStockAndFlowStructureF) = [pname(sf,p) for p in 1:np(sf)]
 
+""" set stock names to vector of symbols"""
 set_snames!(p::AbstractStockAndFlow0, names) = set_subpart!(p, :sname, names)
+""" set flow names to vector of symbols"""
 set_fnames!(p::AbstractStockAndFlowStructure, names) = set_subpart!(p, :fname, names)
+""" set sum variable names to vector of symbols"""
 set_svnames!(p::AbstractStockAndFlow0, names) = set_subpart!(p, :svname, names)
+""" set dynamic variable names to vector of symbols"""
 set_vnames!(p::AbstractStockAndFlowStructure, names) = set_subpart!(p, :vname, names)
+""" set parameter names to vector of symbols"""
 set_pnames!(p::AbstractStockAndFlowStructure, names) = set_subpart!(p, :pname, names)
 
 
@@ -579,11 +616,12 @@ set_pname!(p::AbstractStockAndFlowStructure, index, newname) = set_subpart!(p, :
 
 
 
-
+""" get flow variable of flow """
 fv(p::AbstractStockAndFlowStructure,f) = subpart(p,f,:fv)
+""" get ordered list of indices of dynamic variable for each flow """
 fvs(p::AbstractStockAndFlowStructure)=[fv(p,f) for f in 1:nf(p)]
 
-# return the pair of names of (stock, sum-auxiliary-variable) for all linkages between them
+""" return the pair of names of (stock, sum-auxiliary-variable) for all linkages between them """
 lsnames(p::AbstractStockAndFlow0) = begin
     s = map(x->subpart(p,x,:lss),collect(1:nls(p)))
     sv = map(x->subpart(p,x,:lssv),collect(1:nls(p)))
@@ -592,49 +630,51 @@ lsnames(p::AbstractStockAndFlow0) = begin
     pssv = collect(zip(sn, svn))
 end
 
-# return inflows of stock index s
+""" return inflows of stock index s """
 inflows(p::AbstractStockAndFlowStructure,s) = subpart(p,incident(p,s,:is),:ifn)
-# return outflows of stock index s
+""" return outflows of stock index s """
 outflows(p::AbstractStockAndFlowStructure,s) = subpart(p,incident(p,s,:os),:ofn)
-# return stocks of flow index f flow in
+
 # TODO: add assertion that the length(instock)=1
+""" return stocks of flow index f flow in """
 instock(p::AbstractStockAndFlowStructure,f) = subpart(p,incident(p,f,:ifn),:is)
-# return stocks of flow index f flow out
+
 # TODO: add assertion that the length(outstock)=1
+""" return stocks of flow index f flow out """
 outstock(p::AbstractStockAndFlowStructure,f) = subpart(p,incident(p,f,:ofn),:os)
-# return stocks of sum variable index sv link to
+""" return stocks of sum variable index sv link to"""
 stockssv(p::AbstractStockAndFlow0,sv) = subpart(p,incident(p,sv,:lssv),:lss)
-# return stocks of auxiliary variable index v link to
+""" return stocks of auxiliary variable index v link to """
 stocksv(p::AbstractStockAndFlowStructure,v) = subpart(p,incident(p,v,:lvv),:lvs)
-# return sum variables of auxiliary variable index v link to
+""" return sum variables of auxiliary variable index v link to """
 svsv(p::AbstractStockAndFlowStructure,v) = subpart(p,incident(p,v,:lsvv),:lsvsv)
-# return sum auxiliary variables a stock s link
+""" return sum auxiliary variables a stock s link """
 svsstock(p::AbstractStockAndFlowStructure,s) = subpart(p,incident(p,s,:lss),:lssv)
-# return auxiliary variables a stock s link
+""" return auxiliary variables a stock s link """
 vsstock(p::AbstractStockAndFlowStructure,s) = subpart(p,incident(p,s,:lvs),:lvv)
-# return auxiliary variables a sum auxiliary variable link
+""" return auxiliary variables a sum auxiliary variable link """
 vssv(p::AbstractStockAndFlowStructure,sv) = subpart(p,incident(p,sv,:lsvsv),:lsvv)
 
 
-# return auxiliary variable's source auxiliary variables that is linked to
+""" return auxiliary variable's source auxiliary variables that is linked to """
 vtgt(p::AbstractStockAndFlowStructureF,v) = subpart(p,incident(p,v,:lvsrc),:lvtgt)
-# return auxiliary variable's target auxiliary variables that links to
+""" return auxiliary variable's target auxiliary variables that links to """
 vsrc(p::AbstractStockAndFlowStructureF,v) = subpart(p,incident(p,v,:lvtgt),:lvsrc)
-# return auxiliary variable's source constant parameters
+""" return auxiliary variable's source constant parameters """
 vpsrc(p::AbstractStockAndFlowStructureF,v) = subpart(p,incident(p,v,:lpvv),:lpvp)
-# return constant parameters's link auxiliary variables
+""" return constant parameters's link auxiliary variables """
 vptgt(p::AbstractStockAndFlowStructureF,pp) = subpart(p,incident(p,pp,:lpvp),:lpvv)
 
 
-# return operator of an auxiliary variable
+""" return operator of an auxiliary variable """
 vop(p::AbstractStockAndFlowF,v) = subpart(p,v,:vop)
-# return argument position of source stock variable of an auxiliary variable
+""" return argument position of source stock variable of an auxiliary variable """
 lvvposition(p::AbstractStockAndFlowF,v) = subpart(p,incident(p,v,:lvv),:lvsposition)
-# return argument position of source auxiliary variable of an auxiliary variable
+""" return argument position of source auxiliary variable of an auxiliary variable """
 lvtgtposition(p::AbstractStockAndFlowF,v) = subpart(p,incident(p,v,:lvtgt),:lvsrcposition)
-# return argument position of source sum dynamical variable of an auxiliary variable
+""" return argument position of source sum dynamical variable of an auxiliary variable """
 lsvvposition(p::AbstractStockAndFlowF,v) = subpart(p,incident(p,v,:lsvv),:lsvsvposition)
-# return argument position of source constant parameter of an auxiliary variable
+""" return argument position of source constant parameter of an auxiliary variable """
 lpvvposition(p::AbstractStockAndFlowF,v) = subpart(p,incident(p,v,:lpvv),:lpvpposition)
 
 # create a dictionary
@@ -646,7 +686,7 @@ make_dict(ks, vs) = begin
     end
     return Dict(dic)
 end
-# create expresision of an auxiliary variable v
+""" create expresision of an auxiliary variable v """
 function make_v_expr(p::AbstractStockAndFlowF,v)
 
     op = vop(p,v)
@@ -692,23 +732,28 @@ eval_function(expr,s,sv,p,us,uNs,ps) = begin
 end
 
 
-# return sum auxiliary variables all stocks link (frequency)
+""" return sum auxiliary variables all stocks link (frequency) """
 svsstockAllF(p::AbstractStockAndFlowStructure) = [((svsstock(p, s) for s in 1:ns(p))...)...]
-# return auxiliary variables all stocks link (frequency)
+""" return auxiliary variables all stocks link (frequency) """
 vsstockAllF(p::AbstractStockAndFlowStructure) = [((vsstock(p, s) for s in 1:ns(p))...)...]
-# return auxiliary variables all sum auxiliary variables link (frequency)
+""" return auxiliary variables all sum auxiliary variables link (frequency) """
 vssvAllF(p::AbstractStockAndFlowStructure) = [((vssv(p, sv) for sv in 1:nsv(p))...)...]
 
-# return all inflows
+""" return all inflows """
 inflowsAll(p::AbstractStockAndFlowStructure) = [((inflows(p, s) for s in 1:ns(p))...)...]
-# return all outflows
+""" return all outflows """
 outflowsAll(p::AbstractStockAndFlowStructure) = [((outflows(p, s) for s in 1:ns(p))...)...]
 
 
 
-# return the functions of variables give index v
+""" 
+    funcDynam(p::AbstractStockAndFlow,v)
+return the functions of variables give index v """
 funcDynam(p::AbstractStockAndFlow,v) = subpart(p,v,:funcDynam)
 
+""" 
+    funcDynam(sf::AbstractStockAndFlowF,v)
+return the functions of variables give index v """
 funcDynam(sf::AbstractStockAndFlowF,v) = begin
     expr=make_v_expr(sf,v)
     args=generate_expr_args(expr)
@@ -726,16 +771,16 @@ funcDynam(sf::AbstractStockAndFlowF,v) = begin
     return f
 end
 
-# return the auxiliary variable's index that related to the flow with index of f
+""" return the auxiliary variable's index that related to the flow with index of f """
 flowVariableIndex(p::AbstractStockAndFlowStructure,f) = subpart(p,f,:fv)
-# return the functions (not substitutes the function of sum variables yet) of flow index f
+""" return the functions (not substitutes the function of sum variables yet) of flow index f """
 funcFlowRaw(p::Union{AbstractStockAndFlow,AbstractStockAndFlowF},f)=funcDynam(p,flowVariableIndex(p,f))
-# return the LVector of pairs: fname => function (raw: not substitutes the function of sum variables yet)
+""" return the LVector of pairs: fname => function (raw: not substitutes the function of sum variables yet) """
 funcFlowsRaw(p::Union{AbstractStockAndFlow,AbstractStockAndFlowF}) = begin
   fnames = [fname(p, f) for f in 1:nf(p)]
   LVector(;[(fnames[f]=>funcFlowRaw(p, f)) for f in 1:nf(p)]...)
 end
-# generate the function substituting sum variables in with flow index fn
+""" generate the function substituting sum variables in with flow index fn """
 funcFlow(pn::Union{AbstractStockAndFlow,AbstractStockAndFlowF}, fn) = begin
     func=funcFlowRaw(pn,fn)
     f(u,p,t) = begin
@@ -743,14 +788,14 @@ funcFlow(pn::Union{AbstractStockAndFlow,AbstractStockAndFlowF}, fn) = begin
         return valueat(func,u,uN,p,t)
     end
 end
-# return the LVector of pairs: fname => function (with function of sum variables substitue in)
+""" return the LVector of pairs: fname => function (with function of sum variables substitue in) """
 funcFlows(p::Union{AbstractStockAndFlow,AbstractStockAndFlowF})=begin
     fnames = [fname(p, f) for f in 1:nf(p)]
     LVector(;[(fnames[f]=>funcFlow(p, f)) for f in 1:nf(p)]...)
 end
 
 
-# generate the function of a sum auxiliary variable (index sv) with the sum of all stocks links to it
+""" generate the function of a sum auxiliary variable (index sv) with the sum of all stocks links to it """
 funcSV(p::AbstractStockAndFlow0,sv) = begin
     uN(u,t) = begin
         sumS = 0
@@ -761,7 +806,7 @@ funcSV(p::AbstractStockAndFlow0,sv) = begin
     end
     return uN
 end
-# return the LVector of pairs: svname => function
+""" return the LVector of pairs: svname => function """
 funcSVs(p::AbstractStockAndFlow0) = begin
   svnames = [svname(p, sv) for sv in 1:nsv(p)]
   LVector(;[(svnames[sv]=>funcSV(p, sv)) for sv in 1:nsv(p)]...)
@@ -769,7 +814,7 @@ end
 
 
 ####################### functions of composition of stock and flow diagram####################
-# Note: the compositional functions currently are only implemented for the StoclFlow diagram (including both structure and functions)
+# Note: the compositional functions currently are only implemented for the StockFlow diagram (including both structure and functions)
 
 # given a stock and flow diagram in schema "StockAndFlow", return a stock and flow diagram in schema "StockAndFlow0"
 object_shift_right(p::StockAndFlowStructure) = begin

--- a/src/StockFlow.jl
+++ b/src/StockFlow.jl
@@ -640,25 +640,25 @@ outflows(p::AbstractStockAndFlowStructure,s) = subpart(p,incident(p,s,:os),:ofn)
 instock(p::AbstractStockAndFlowStructure,f) = subpart(p,incident(p,f,:ifn),:is)
 
 # TODO: add assertion that the length(outstock)=1
-""" return stocks of flow index f flow out """
+""" return stocks that flow index f flow out from """
 outstock(p::AbstractStockAndFlowStructure,f) = subpart(p,incident(p,f,:ofn),:os)
-""" return stocks of sum variable index sv link to"""
+""" return stocks that sum variable index sv link to """
 stockssv(p::AbstractStockAndFlow0,sv) = subpart(p,incident(p,sv,:lssv),:lss)
-""" return stocks of auxiliary variable index v link to """
+""" return stocks that auxiliary variable index v link to """
 stocksv(p::AbstractStockAndFlowStructure,v) = subpart(p,incident(p,v,:lvv),:lvs)
-""" return sum variables of auxiliary variable index v link to """
+""" return sum variables that auxiliary variable index v link to """
 svsv(p::AbstractStockAndFlowStructure,v) = subpart(p,incident(p,v,:lsvv),:lsvsv)
-""" return sum auxiliary variables a stock s link """
+""" return sum auxiliary variables that stock s links to """
 svsstock(p::AbstractStockAndFlowStructure,s) = subpart(p,incident(p,s,:lss),:lssv)
-""" return auxiliary variables a stock s link """
+""" return auxiliary variables that stock s links to """
 vsstock(p::AbstractStockAndFlowStructure,s) = subpart(p,incident(p,s,:lvs),:lvv)
-""" return auxiliary variables a sum auxiliary variable link """
+""" return auxiliary variables that sum auxiliary variable sv links to """
 vssv(p::AbstractStockAndFlowStructure,sv) = subpart(p,incident(p,sv,:lsvsv),:lsvv)
 
 
-""" return auxiliary variable's source auxiliary variables that is linked to """
+""" return auxiliary variable's source auxiliary variables that it links to """
 vtgt(p::AbstractStockAndFlowStructureF,v) = subpart(p,incident(p,v,:lvsrc),:lvtgt)
-""" return auxiliary variable's target auxiliary variables that links to """
+""" return auxiliary variable's target auxiliary variables it links to """
 vsrc(p::AbstractStockAndFlowStructureF,v) = subpart(p,incident(p,v,:lvtgt),:lvsrc)
 """ return auxiliary variable's source constant parameters """
 vpsrc(p::AbstractStockAndFlowStructureF,v) = subpart(p,incident(p,v,:lpvv),:lpvp)

--- a/src/SystemStructure.jl
+++ b/src/SystemStructure.jl
@@ -37,6 +37,9 @@ function extracStocksStructureAndFlatten(p::AbstractStockAndFlowStructure)
     return s
 end
 
+"""
+Return stock names as Symbol, along with the linked flows and sum variables
+"""
 function extracStocksStructureAndFlatten(p::AbstractStockAndFlowStructureF)
     s=[]
     
@@ -63,6 +66,9 @@ function extracStocksStructureAndFlatten(p::AbstractStockAndFlowStructureF)
     return s
 end
 
+"""
+Return flow names as Symbol, along with the linked flow variables
+"""
 function extracFlowsStructureAndFlatten(p::AbstractStockAndFlowStructure)
     f=[]
     
@@ -82,6 +88,9 @@ function extracFlowsStructureAndFlatten(p::AbstractStockAndFlowStructure)
     return f
 end
 
+"""
+Return parameter names as Symbol
+"""
 function extracPsStructureAndFlatten(p::AbstractStockAndFlowStructureF)
     pns=[]
     
@@ -116,6 +125,9 @@ function extracSumVStructureAndFlatten(p::AbstractStockAndFlowStructure)
     return sv
 end
 
+"""
+Return sum variable names as Symbol, along with the linked dynamic variables
+"""
 function extracSumVStructureAndFlatten(p::AbstractStockAndFlowStructureF)
     sv=[]
     
@@ -130,6 +142,9 @@ function extracSumVStructureAndFlatten(p::AbstractStockAndFlowStructureF)
     return sv
 end
 
+"""
+Return a Tuple of Vectors of Symbols of flattened stocks, sums, parameters and source dynamic variables a dynamic variable at index v links to.
+"""
 function args_vname(p::AbstractStockAndFlowStructureF,v)
     srcsv=map(i->(flattenTupleNames(sname(p,i))),stocksv(p,v))
     srcsvv=map(i->(flattenTupleNames(svname(p,i))),svsv(p,v))
@@ -148,11 +163,19 @@ function args_vnamexxxx(p::AbstractStockAndFlowStructureF,v)
     return (srcsv,srcsvv,srcpv,srcvv)
 end
 
+"""
+    args(p::AbstractStockAndFlowStructureF,v)
+Return a Vector of Symbols of flattened stocks, sums, parameters and source dynamic variables a dynamic variable at index v links to.
+"""
 function args(p::AbstractStockAndFlowStructureF,v)
     (srcsv,srcsvv,srcpv,srcvv)=args_vname(p,v)
     return vcat(srcsv,srcsvv,srcpv,srcvv)
 end
 
+"""
+    args(p::AbstractStockAndFlowF,v)
+Return a Vector of Symbols of flattened stocks, sums, parameters and source dynamic variables a dynamic variable at index v links to.
+"""
 function args(p::AbstractStockAndFlowF,v)
     (srcsv,srcsvv,srcpv,srcvv)=args_vname(p,v)
        
@@ -169,6 +192,9 @@ function args(p::AbstractStockAndFlowF,v)
     return srcs
 end
 
+"""
+Return dynamic variable definitions as Vector with elements of form :dv => [:arg1, :arg2]
+"""
 extracVStructureAndFlatten(p::AbstractStockAndFlowStructureF) = begin
 
     vs=[]
@@ -184,6 +210,9 @@ extracVStructureAndFlatten(p::AbstractStockAndFlowStructureF) = begin
     
 end
 
+"""
+Convert dynamic variable names to Symbol, convert all operators to a single operator if they are equal else throw an error, and  
+"""
 extracVAndAttrStructureAndFlatten(p::AbstractStockAndFlowF) = begin
 
     vs=[]
@@ -208,6 +237,9 @@ function rebuildStratifiedModelByFlattenSymbols(p::AbstractStockAndFlowStructure
     return StockAndFlowStructure(s,f,sv)
 end
 
+"""
+Return a new stock flow with flattened names, operators and positions from the old
+"""
 function rebuildStratifiedModelByFlattenSymbols(p::AbstractStockAndFlowF)
     s=extracStocksStructureAndFlatten(p)
     pr=extracPsStructureAndFlatten(p)
@@ -218,7 +250,6 @@ function rebuildStratifiedModelByFlattenSymbols(p::AbstractStockAndFlowF)
     return StockAndFlowF(s,pr,v,f,sv)
 end
 
-
 function convertSystemStructureToStockFlow(p::AbstractStockAndFlowStructure,v)   
     s=extracStocksStructureAndFlatten(p)
     f=extracFlowsStructureAndFlatten(p)
@@ -227,6 +258,13 @@ function convertSystemStructureToStockFlow(p::AbstractStockAndFlowStructure,v)
     return StockAndFlow(s,f,v,sv)
 end
 
+"""
+Return a new stock flow with flattened names, operators and positions from an AbstractStockAndFlowStructureF.
+Need to provide dynamic variable definitions, eg
+```julia
+convertSystemStructureToStockFlow(MyStockFlowStructure, (:v_prevalence=>(:I,:N,:/),:v_meanInfectiousContactsPerS=>(:c,:v_prevalence,:*)))
+```
+"""
 function convertSystemStructureToStockFlow(p::AbstractStockAndFlowStructureF,v)   
     s=extracStocksStructureAndFlatten(p)
     pr=extracPsStructureAndFlatten(p)
@@ -245,6 +283,9 @@ function convertStockFlowToSystemStructure(p::AbstractStockAndFlow)
     return StockAndFlowStructure(s,f,sv)
 end
 
+""" 
+Return a new StockAndFlowStructureF with flattened names, operators and positions from an AbstractStockAndFlowF.
+"""
 function convertStockFlowToSystemStructure(p::AbstractStockAndFlowF)
     
     s=extracStocksStructureAndFlatten(p)

--- a/src/SystemStructure.jl
+++ b/src/SystemStructure.jl
@@ -263,8 +263,10 @@ Concatenate Symbols.
 ++(a::Symbol,b::Symbol) = Symbol(string(a, b))
 
 """
-Modify a AbstractStockAndFlowStructureF so named elements end with suffix.
-"""
+    add_suffix!(sf::AbstractStockAndFlow0, suffix)
+
+Modify a AbstractStockAndFlow0 so named elements end with suffix.
+Suffix can be anything which can be cast to a Symbol."""
 function add_suffix!(sf::AbstractStockAndFlowStructureF, suffix)
     suffix = Symbol(suffix)
     set_snames!(sf, snames(sf) .++ suffix)
@@ -277,7 +279,10 @@ end
 
 
 """
+    add_suffix!(sf::AbstractStockAndFlow0, suffix)
+
 Modify a AbstractStockAndFlow0 so named elements end with suffix.
+Suffix can be anything which can be cast to a Symbol.
 For feet.
 """
 function add_suffix!(sf::AbstractStockAndFlow0, suffix)
@@ -288,7 +293,10 @@ function add_suffix!(sf::AbstractStockAndFlow0, suffix)
 end
 
 """
+    add_prefix!(sf::AbstractStockAndFlowStructureF, prefix)
+
 Modify a AbstractStockAndFlowStructureF so named elements begin with prefix
+Prefix can be anything which can be cast to a Symbol.
 """
 function add_prefix!(sf::AbstractStockAndFlowStructureF, prefix)
     prefix = Symbol(prefix)
@@ -301,8 +309,10 @@ function add_prefix!(sf::AbstractStockAndFlowStructureF, prefix)
 end
 
 """
-Modify a AbstractStockAndFlow0 so named elements begin with prefix.
-For feet.
+    add_prefix!(sf::AbstractStockAndFlowStructureF, prefix)
+
+Modify a AbstractStockAndFlowStructureF so named elements begin with prefix
+Prefix can be anything which can be cast to a Symbol.For feet.
 """
 function add_prefix!(sf::AbstractStockAndFlow0, prefix)
     prefix = Symbol(prefix)

--- a/src/SystemStructure.jl
+++ b/src/SystemStructure.jl
@@ -154,15 +154,6 @@ function args_vname(p::AbstractStockAndFlowStructureF,v)
     return (srcsv,srcsvv,srcpv,srcvv)
 end
 
-function args_vnamexxxx(p::AbstractStockAndFlowStructureF,v)
-    srcsv=map(i->Symbol(join(sname(p,i))),stocksv(p,v))
-    srcsvv=map(i->Symbol(join(svname(p,i))),svsv(p,v))
-    srcpv=map(i->Symbol(join(pname(p,i))),vpsrc(p,v))
-    srcvv=map(i->Symbol(join(vname(p,i))),vsrc(p,v))
-
-    return (srcsv,srcsvv,srcpv,srcvv)
-end
-
 """
     args(p::AbstractStockAndFlowStructureF,v)
 Return a Vector of Symbols of flattened stocks, sums, parameters and source dynamic variables a dynamic variable at index v links to.


### PR DESCRIPTION

An attempt to get closer to the [Catlab style guide](https://algebraicjulia.github.io/Catlab.jl/latest/devdocs/style/) by adding additional docstrings for exported files.  Don't do it to all of them, and most still aren't complete sentences, so still have a long way to go.

I think the only non-comment change is removing svStock from the export list in StockFlow.jl, because it doesn't exist.

Also gives more things to be added to the generated documentation.
![image](https://github.com/AlgebraicJulia/StockFlow.jl/assets/61016353/c99c06ec-44eb-4f23-b8fa-7925b3d5ae93)
![image](https://github.com/AlgebraicJulia/StockFlow.jl/assets/61016353/f9f4a6c4-bf94-46a3-a48a-03cd34ad415c)

