### PR TITLE
Compose updates

### DIFF
--- a/src/syntax/Composition.jl
+++ b/src/syntax/Composition.jl
@@ -10,7 +10,6 @@ import ..Syntax: create_foot
 import Catlab.Programs.RelationalPrograms: UntypedUnnamedRelationDiagram
 
 
-RETURN_UWD = false
 
 """
 Construct a uwd to compose your open stockflows
@@ -76,40 +75,48 @@ sirv = sfcompose(sir, svi, quote
 end)
 
 Cannot use () => () as a foot, 
-the length of the first tuple must be the same as the number of stock flows given as argument,
-and every foot can only be used once.
+the length of the first tuple must be the same as the number of stock flows
+given as argument, and every foot can only be used once.
 """
-function sfcompose(sfs::Vector{K}, block::Expr) where {K <: AbstractStockAndFlowF}#(sf1, sf2, ..., block)
-
-
+function sfcompose(sfs::Vector{K}, block::Expr; RETURN_UWD = false) where {K <: AbstractStockAndFlowF} # (sf1, sf2, ..., block)
 
     Base.remove_linenums!(block)
-    sf_names = block.args[1].args
-  
-    if length(sfs) == 0 # Composing 0 stock flows should give you an empty stock flow
+    if length(sfs) == 0
         return StockAndFlowF()
-   end
+    end
 
-   @assert length(sf_names) == length(sfs) "The number of symbols on the first line is not the same as the number of stock flow arguments provided.  Stockflow #: $(length(sfs)) Symbol #: $(length(sf_names))"
+    if length(block.args) == 0 # equivalent to coproduct
+        # If sf_names is empty, there can't be any arguments after it.
+        sf_names = [gensym() for _ in 1:length(sfs)]
+    else
+        sf_names = block.args[1].args
+    end
+  
+    # If the tuple of aliases is smaller than 
+    if length(sf_names) < length(sfs)
+        len_diff = length(sfs) - length(sf_names)
+        append!(sf_names, [gensym() for _ in 1:len_diff])
+    end
 
 
-
-    @assert allunique(sf_names) "Not all choices of names for stock flows are unique!"
-
+    @assert allunique(sf_names) "Not all choices of names for stock flows \
+    are unique!"
 
     empty_foot =  (@foot () => ())
 
 
     # symbol representation of sf => (sf itself, sf's feet)
     # Every sf has empty foot as first foot to get around being unable to create OpenStockAndFlowF without feet
-    sf_map::Dict{Symbol, Tuple{AbstractStockAndFlowF, Vector{StockAndFlow0}}} = Dict(sf_names[i] => (sfs[i], [empty_foot]) for i ∈ eachindex(sf_names)) # map the symbols to their corresponding stockflows
-    
+    sf_map::Dict{Symbol, Tuple{AbstractStockAndFlowF, Vector{StockAndFlow0}}} = 
+        Dict(sf_names[i] => (sfs[i], [empty_foot]) for i ∈ eachindex(sf_names)) # map the symbols to their corresponding stockflows
+
     # all feet
     feet_index_dict::Dict{StockAndFlow0, Int} = Dict(empty_foot => 1)
     for statement in block.args[2:end]
         stockflows, foot = interpret_composition_notation(statement)
         # adding new foot to list
-        @assert (foot ∉ keys(feet_index_dict)) "Foot has already been used, or you are using an empty foot!"
+        @assert (foot ∉ keys(feet_index_dict)) "Foot has already been used,\
+         or you are using an empty foot!"
         push!(feet_index_dict, foot => length(feet_index_dict) + 1)
         for stockflow in stockflows
             # adding this foot to each stock flow to its left
@@ -122,6 +129,15 @@ function sfcompose(sfs::Vector{K}, block::Expr) where {K <: AbstractStockAndFlow
 
     Port = Vector{Tuple{Int, Int}}()
 
+    # for each (alias, (sf, sf's feet)) 
+    #   for each foot in sf's feet
+    #       grab the index of a foot
+    #       grab the index of alias
+    #       push (alias index, foot index) to port
+
+
+
+
     for (k, v) ∈ sf_map # TODO: Just find a better way to do this.
         for foot ∈ v[2]
             push!(Port, (findfirst(x -> x == k, sf_names), feet_index_dict[foot]))
@@ -133,13 +149,9 @@ function sfcompose(sfs::Vector{K}, block::Expr) where {K <: AbstractStockAndFlow
 
     uwd = create_uwd(Box=Box, Port=Port, Junction=Junction, OuterPort=OuterPort)
 
-    # I'd prefer this to be a vector, but oapply didn't like that
-    # I'd also prefer that I don't include the empty foot, but Open doesn't want to accept stockflows with no feet.
-    # open_stockflows::AbstractDict = Dict(sf_key => Open(sf_val, foot_dict[sf_val]...,) for (sf_key, sf_val) ∈ sf_map)
-
     open_stockflows::AbstractDict = Dict(sf_key => Open(sf_val[1], sf_val[2]...) for (sf_key, sf_val) ∈ sf_map)
 
-    if RETURN_UWD # UWD might be a bit screwed up from the empty foot being first.
+    if RETURN_UWD
         return apex(oapply(uwd, open_stockflows)), uwd
     else
         return apex(oapply(uwd, open_stockflows))
@@ -153,7 +165,8 @@ Compose models.
 """
 macro compose(args...)
     if length(args) == 0
-        return :(MethodError("No arguments provided!  Please provide some number of stockflows, then a quote block."))
+        return :(MethodError("No arguments provided!  Please provide some \
+        number of stockflows, then a quote block."))
     end
     escaped_block = Expr(:quote, args[end])
     sfs = esc.(args[1:end-1])

--- a/test/syntax/Composition.jl
+++ b/test/syntax/Composition.jl
@@ -1,3 +1,6 @@
+using Pkg;
+Pkg.activate(".")
+
 using Test
 using StockFlow
 using StockFlow.Syntax
@@ -6,7 +9,17 @@ import StockFlow.Syntax.Composition: interpret_composition_notation
 
 @testset "Composition creates expected stock flows" begin
     empty_sf = StockAndFlowF()
+    A = @stock_and_flow begin; :stocks; A; end;
+    AA = @stock_and_flow begin; :stocks; A; A; end;
+    
+    B = @stock_and_flow begin; :stocks; B; end;
+    AB = @stock_and_flow begin :stocks; A; B; end; 
+    BA = @stock_and_flow begin :stocks; B; A; end; 
 
+
+
+    @test (@compose (begin # composing no stock flows returns an empty stock flow.
+    end)) == empty_sf
 
     @test (@compose (begin # composing no stock flows returns an empty stock flow.
         ()
@@ -16,18 +29,30 @@ import StockFlow.Syntax.Composition: interpret_composition_notation
         (sf,)
     end) == empty_sf
 
-    @test (@compose (@stock_and_flow begin; :stocks; A; end;) (@stock_and_flow begin; :stocks; B; end;) (begin
-        (sf1, sf2)
-    end)) == (@stock_and_flow begin; :stocks; A; B; end;) # Combining without any composing
+    @test (@compose A begin
+        (sf,)
+    end) == A
 
-    @test (@compose (@stock_and_flow begin; :stocks; A; end;) (@stock_and_flow begin; :stocks; A; end;) (begin
+    @test (@compose A B (begin
         (sf1, sf2)
-    end)) == (@stock_and_flow begin; :stocks; A; A; end;)
+    end)) == AB # Combining without any composing
 
-    @test (@compose (@stock_and_flow begin; :stocks; A; end;) (@stock_and_flow begin; :stocks; A; end;) (begin
+    @test (@compose A A  (begin
+        (sf1, sf2)
+    end)) == AA
+
+    @test (@compose A A (begin
         (sf1, sf2)
         sf1, sf2 ^ A => ()
-    end)) == (@stock_and_flow begin; :stocks; A; end;)
+    end)) == A
+
+    @test (@compose A B (begin
+    end)) == AB
+
+    @test (@compose B B A (begin
+        (B1, B2)
+        B1, B2 ^ B => ()
+        end)) == BA
 
     @test ((@compose (@stock_and_flow begin
         :stocks
@@ -102,8 +127,4 @@ end
         sf1 ^ A => ()
         sf2 ^ A => ()
     end) # not allowed to map to the same foot twice
-    @test_throws AssertionError sfcompose([(@stock_and_flow begin; :stocks; A; end;), (@stock_and_flow begin; :stocks; A; end;)], quote
-        (sf1,)
-        sf1 ^ A => ()
-    end) # incorrect number of symbols on the first line in the quote
 end

--- a/test/syntax/Composition.jl
+++ b/test/syntax/Composition.jl
@@ -1,6 +1,3 @@
-using Pkg;
-Pkg.activate(".")
-
 using Test
 using StockFlow
 using StockFlow.Syntax


### PR DESCRIPTION
- It's no longer required that the first line be the same length as the number of stockflows being given as argument.  Those not assigned an alias are assumed to be composed on no feet (except empty)
- It is now valid syntax to provide an empty block to @ compose, eg @ compose begin end.  This returns an empty stockflow.
- Updated tests
- Minor comment updates