### PR TITLE
Add ternary operation in stockflow macro syntax

### DIFF
--- a/src/StockFlow.jl
+++ b/src/StockFlow.jl
@@ -40,6 +40,8 @@ vectorify(n) = [n]
 state_dict(n) = Dict(s=>i for (i, s) in enumerate(n))
 
 cond(c,t,f) = c ? t : f
+or(a,b) = a || b
+and(a,b) = a && b
 
 #= operators definition
 # Operators:

--- a/src/StockFlow.jl
+++ b/src/StockFlow.jl
@@ -525,7 +525,6 @@ sir_StockAndFlow=StockAndFlowF((:S=>(:F_NONE,:inf,:N), :I=>(:inf,:F_NONE,:N)),
 ```
 """
 StockAndFlowF(s,p,v,f,sv) = begin
-  @show s, p, v, f, sv
   sf = StockAndFlowF()
 
   s = vectorify(s)

--- a/src/StockFlow.jl
+++ b/src/StockFlow.jl
@@ -39,6 +39,8 @@ vectorify(n) = [n]
 
 state_dict(n) = Dict(s=>i for (i, s) in enumerate(n))
 
+cond(c,t,f) = c ? t : f
+
 #= operators definition
 # Operators:
 
@@ -523,6 +525,7 @@ sir_StockAndFlow=StockAndFlowF((:S=>(:F_NONE,:inf,:N), :I=>(:inf,:F_NONE,:N)),
 ```
 """
 StockAndFlowF(s,p,v,f,sv) = begin
+  @show s, p, v, f, sv
   sf = StockAndFlowF()
 
   s = vectorify(s)

--- a/src/StockFlow.jl
+++ b/src/StockFlow.jl
@@ -40,8 +40,8 @@ vectorify(n) = [n]
 state_dict(n) = Dict(s=>i for (i, s) in enumerate(n))
 
 cond(c,t,f) = c ? t : f
-or(a,b) = a || b
-and(a,b) = a && b
+or(a,b) = Bool(a) || Bool(b)
+and(a,b) = Bool(a) && Bool(b)
 
 #= operators definition
 # Operators:
@@ -70,7 +70,7 @@ https://docs.julialang.org/en/v1/manual/mathematical-operations/
 Operators = Dict(2 => [:+, :-, :*, :/, :÷, :^, :%, :log, Symbol("")],
                  1 => [:log, :exp, :sqrt, Symbol("")]) #:NN is for NONE, which is used in create the special diagram using graph rewriting
 
-
+math_expr(op, op1, op2, op3) = Expr(:call, op, op1, op2, op3)
 math_expr(op, op1, op2) = Expr(:call, op, op1, op2)
 math_expr(op, op1) = Expr(:call, op, op1)
 #math_expr(op) = Expr(:call, op)

--- a/test/Syntax.jl
+++ b/test/Syntax.jl
@@ -597,3 +597,17 @@ end
     end) == CausalLoopPM([:A, :B], [:A => :B, :B => :A], [POL_NEGATIVE, POL_POSITIVE])
 
 end
+
+
+
+@testset "Ternary" begin
+        @test ((@stock_and_flow begin
+                       :stocks
+                       A
+                       B
+                       C
+                       :dynamic_variables
+                       cond = A == B
+                       v = cond ? A : B
+              end) == StockAndFlowF([:A => (:F_NONE, :F_NONE, :SV_NONE), :B => (:F_NONE, :F_NONE, :SV_NONE)], [], [:cond => ((:A, :B) => :(==)), :v => ((:cond, :A, :B) => :cond)], [], []))
+end

--- a/test/Syntax.jl
+++ b/test/Syntax.jl
@@ -609,5 +609,5 @@ end
                        :dynamic_variables
                        cond = A == B
                        v = cond ? A : B
-              end) == StockAndFlowF([:A => (:F_NONE, :F_NONE, :SV_NONE), :B => (:F_NONE, :F_NONE, :SV_NONE)], [], [:cond => ((:A, :B) => :(==)), :v => ((:cond, :A, :B) => :cond)], [], []))
+              end) == StockAndFlowF([:A => (:F_NONE, :F_NONE, :SV_NONE), :B => (:F_NONE, :F_NONE, :SV_NONE), :C => (:F_NONE, :F_NONE, :SV_NONE)], [], [:cond => ((:A, :B) => :(==)), :v => ((:cond, :A, :B) => :cond)], [], []))
 end


### PR DESCRIPTION
Allows use of the syntax A = B ? C : D in a dynamic variable, where B, C and D can be symbols or expressions.  An expression of this form is converted into a function call cond(B,C,D) = B ? C : D