### PR TITLE
Fix StockFlow.jl build

### DIFF
--- a/.github/workflows/julia_ci.yml
+++ b/.github/workflows/julia_ci.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: 0 0 * * *
   push:
+      branches: ["main"]
+      tags: ["*"]
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/julia_ci.yml
+++ b/.github/workflows/julia_ci.yml
@@ -4,8 +4,8 @@ on:
   schedule:
     - cron: 0 0 * * *
   push:
-      branches: ["main"]
-      tags: ["*"]
+    branches: ["main"]
+    tags: ["*"]
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/julia_ci.yml
+++ b/.github/workflows/julia_ci.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: 0 0 * * *
   push:
-    branches: ["main"]
-    tags: ["*"]
   pull_request:
   workflow_dispatch:
     inputs:

--- a/src/StockFlow.jl
+++ b/src/StockFlow.jl
@@ -15,9 +15,6 @@ make_v_expr_nonrecursive, get_lpvpposition, get_lvsrcposition, get_lsvsvposition
 
 
 using Catlab
-using Catlab.CategoricalAlgebra
-using Catlab.CategoricalAlgebra.FinSets
-using Catlab.Theories
 using LabelledArrays
 using LinearAlgebra: mul!
 import Base.+,Base.-

--- a/src/syntax/Composition.jl
+++ b/src/syntax/Composition.jl
@@ -3,11 +3,9 @@ export sfcompose, @compose
 
 using ...StockFlow
 using ..Syntax
-using Catlab.CategoricalAlgebra
-using Catlab.WiringDiagrams
+using Catlab
 
 import ..Syntax: create_foot
-import Catlab: UntypedRelationDiagram
 
 using MLStyle
 

--- a/src/syntax/Composition.jl
+++ b/src/syntax/Composition.jl
@@ -7,7 +7,7 @@ using Catlab.CategoricalAlgebra
 using Catlab.WiringDiagrams
 
 import ..Syntax: create_foot
-import Catlab.Programs.RelationalPrograms: UntypedUnnamedRelationDiagram
+import Catlab: UntypedRelationDiagram
 
 using MLStyle
 
@@ -22,7 +22,7 @@ function create_uwd(;
     Junction::Vector{Symbol} = Vector{Symbol}() # A symbol for each (unique) foot
     )
 
-    uwd = UntypedUnnamedRelationDiagram{Symbol, Symbol}(0)
+    uwd = UntypedRelationDiagram{Symbol, Symbol}(0)
     add_parts!(uwd, :Box, length(Box), name=Box)
     add_parts!(uwd, :Junction, length(Junction), variable=Junction)
     add_parts!(uwd, :Port, length(Port), box=map(first, Port), junction=map(last, Port))
@@ -73,7 +73,7 @@ sirv = sfcompose(sir, svi, quote
     (sr, sv) ^ S => N, I => N
 end)
 
-Cannot use () => () as a foot, 
+Cannot use () => () as a foot,
 the length of the first tuple must be the same as the number of stock flows
 given as argument, and every foot can only be used once.
 """
@@ -90,8 +90,8 @@ function sfcompose(sfs::Vector, block::Expr, main_type, foot_type, create_foot_f
     else
         sf_names = block.args[1].args
     end
-  
-    # If the tuple of aliases is smaller than 
+
+    # If the tuple of aliases is smaller than
     if length(sf_names) < length(sfs)
         len_diff = length(sfs) - length(sf_names)
         append!(sf_names, [gensym() for _ in 1:len_diff])
@@ -106,7 +106,7 @@ function sfcompose(sfs::Vector, block::Expr, main_type, foot_type, create_foot_f
 
     # symbol representation of sf => (sf itself, sf's feet)
     # Every sf has empty foot as first foot to get around being unable to create OpenStockAndFlowF without feet
-    sf_map::Dict{Symbol, Tuple{main_type, Vector{foot_type}}} = 
+    sf_map::Dict{Symbol, Tuple{main_type, Vector{foot_type}}} =
         Dict(sf_names[i] => (sfs[i], [empty_foot]) for i ∈ eachindex(sf_names)) # map the symbols to their corresponding stockflows
 
     # all feet
@@ -128,7 +128,7 @@ function sfcompose(sfs::Vector, block::Expr, main_type, foot_type, create_foot_f
 
     Port = Vector{Tuple{Int, Int}}()
 
-    # for each (alias, (sf, sf's feet)) 
+    # for each (alias, (sf, sf's feet))
     #   for each foot in sf's feet
     #       grab the index of a foot
     #       grab the index of alias

--- a/src/syntax/Rewrite.jl
+++ b/src/syntax/Rewrite.jl
@@ -7,12 +7,11 @@ export sfrewrite, @rewrite
 using ...StockFlow
 
 using ..Syntax
-import ..Syntax: parse_dyvar, parse_flow, parse_sum, parse_stock, 
+import ..Syntax: parse_dyvar, parse_flow, parse_sum, parse_stock,
 parse_param, sf_to_block, StockAndFlowBlock, stock_and_flow_syntax_to_arguments
 
 
-using Catlab.ACSets.ACSetInterface
-using Catlab.CategoricalAlgebra
+using Catlab
 using AlgebraicRewriting
 using AlgebraicRewriting: rewrite
 
@@ -24,8 +23,8 @@ Convert a stockflow block to a stockflow
 """
 function block_to_sf(block)
   args = stock_and_flow_syntax_to_arguments(block)
-  sf = StockAndFlowF(args.stocks, args.params,  
-    map(kv -> kv.first => StockFlow.Syntax.get(kv.second), args.dyvars), 
+  sf = StockAndFlowF(args.stocks, args.params,
+    map(kv -> kv.first => StockFlow.Syntax.get(kv.second), args.dyvars),
     args.flows, args.sums)
   return sf
 end
@@ -50,7 +49,7 @@ function reset_positions!(sfold, sfnew)
 
 
 
-  
+
   newlv = zip(get_lvs(sfnew), get_lvv(sfnew))
   newlsv = zip(get_lsvsv(sfnew), get_lsvv(sfnew))
   newlvv = zip(get_lvsrc(sfnew), get_lvtgt(sfnew))
@@ -71,8 +70,8 @@ function reset_positions!(sfold, sfnew)
   used_lsvsv = Set{Tuple{Int, Int}}()
   used_lvsrc = Set{Tuple{Int, Int}}()
   used_lpvp = Set{Tuple{Int, Int}}()
-  
-  
+
+
   #2: iterate over all new values, find what they link to in new, use that to find the corresponding symbol in old
 
 
@@ -82,8 +81,8 @@ function reset_positions!(sfold, sfnew)
   restored_lvsrcposition = subpart(sfnew, :lvsrcposition)
   restored_lpvpposition = subpart(sfnew, :lpvpposition)
 
-  
-  
+
+
   for (lv, (lvs, lvv)) ∈ enumerate(newlv)
     n1 = newsnames[lvs]
     n2 = newvnames[lvv]
@@ -100,7 +99,7 @@ function reset_positions!(sfold, sfnew)
     restored_lvsposition[lv] = old_pos
   end
 
-    
+
   for (lsv, (lsvsv, lsvv)) ∈ enumerate(newlsv)
     n1 = newsvnames[lsvsv]
     n2 = newvnames[lsvv]
@@ -117,7 +116,7 @@ function reset_positions!(sfold, sfnew)
     restored_lsvsvposition[lsv] = old_pos
   end
 
-  
+
   for (lvv, (lvsrc, lvtgt)) ∈ enumerate(newlvv)
        n1 = newvnames[lvsrc]
     n2 = newvnames[lvtgt]
@@ -220,12 +219,12 @@ function recursively_add_dyvars_L!(current_dyvar, sf_block, new_block, new_set, 
   dyvar_name = current_dyvar[1]
   dyvar_copy = deepcopy(current_dyvar)
   dyvar_definition = dyvar_copy[2]
-    
+
   if dyvar_name ∉ new_set
     push!(new_block.dyvars, dyvar_copy)
     push!(new_set, dyvar_name => dyvar_copy)
   end
-    
+
   # For everything not yet in the dict, add to dict
   for object ∈ filter(∉(new_set), dyvar_definition.args[2:end])
     object_type = name_dict[object][1]
@@ -238,17 +237,17 @@ function recursively_add_dyvars_L!(current_dyvar, sf_block, new_block, new_set, 
     if object_type == :V
       recursively_add_dyvars_L!(object_definition, sf_block, new_block, new_set, name_dict)
     end
-    
+
   end
-  
+
 end
-        
-        
+
+
 
 """
 For every dyvar in the original stockflow which contains a link to object_name:
 - If it hasn't been already, add the original dyvar definition to L's dyvars
-- Add all objects which are a part of the dyvar to L. 
+- Add all objects which are a part of the dyvar to L.
   (Deal with recursively adding dyvars at end)
 """
 function remove_from_dyvars!(object_name, sf_block, L_block, L_set, name_dict)
@@ -258,12 +257,12 @@ function remove_from_dyvars!(object_name, sf_block, L_block, L_set, name_dict)
     if object_name ∉ dyvar_expression.args || dyvar_name ∈ L_set
       continue
     end
-  
+
     push!(L_block.dyvars, dyvar)
     push!(L_set, dyvar_name)
     for particular_object ∈ dyvar_expression.args[2:end]
       if particular_object ∉ L_set
-        
+
 
         object_type = name_dict[particular_object][1]
         object_index = name_dict[particular_object][2]
@@ -279,12 +278,12 @@ end
 """
 For every dyvar in the original stockflow which contains a link to src:
 - If it hasn't been already, add the original dyvar definition to L's dyvars
-- Add all objects which are a part of the dyvar to L. 
+- Add all objects which are a part of the dyvar to L.
   (Deal with recursively adding dyvars at end)
 - Create a new dyvar with src replaced with tgt and add to R
 """
 function swap_from_dyvars!(src, tgt, sf_block, L_block, L_set, R_block, R_dict, name_dict)
-  # check every dyvar to see if it contains src 
+  # check every dyvar to see if it contains src
   for dyvar ∈ sf_block.dyvars
     dyvar_name = dyvar[1]
     dyvar_expression = dyvar[2]
@@ -294,8 +293,8 @@ function swap_from_dyvars!(src, tgt, sf_block, L_block, L_set, R_block, R_dict, 
         push!(L_set, dyvar_name)
         for particular_object ∈ dyvar_expression.args[2:end]
           if particular_object ∉ L_set
-            
-            
+
+
             object_type = name_dict[particular_object][1]
             object_index = name_dict[particular_object][2]
             object_definition = get_from_correct_vector(sf_block, object_index, object_type)
@@ -344,7 +343,7 @@ function recursively_add_dyvars_R!(current_dyvar, sf_block, new_block, new_dict,
     object_type = name_dict[object][1]
     object_index = name_dict[object][2]
     object_definition = get_from_correct_vector(sf_block, object_index, object_type)
-    if object_definition isa Symbol  
+    if object_definition isa Symbol
       push!(new_dict, object => (object_definition,))
     else
       push!(new_dict, object => object_definition)
@@ -356,12 +355,12 @@ function recursively_add_dyvars_R!(current_dyvar, sf_block, new_block, new_dict,
     if object_type == :V
       recursively_add_dyvars_R!(object_definition, sf_block, new_block, new_dict, name_dict)
     end
-    
+
   end
-  
+
 end
-        
-        
+
+
 """
 Function call to create a new stockflow,
 using an existing stockflow and a block describing the modifications.
@@ -372,7 +371,7 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
   @assert allunique(name_vector) "Not all names are unique!  $(filter(x -> count(y -> y == x, name_vector) >= 2, name_vector))"
 
   sf_block::StockAndFlowBlock = sf_to_block(sf)
-  
+
   L_stocks::Vector{Symbol} = []
   L_params::Vector{Symbol} = []
   L_dyvars::Vector{Tuple{Symbol,Expr}} = []
@@ -380,7 +379,7 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
   L_sums::Vector{Tuple{Symbol,Vector{Symbol}}} = []
 
   L_block = StockAndFlowBlock(L_stocks, L_params, L_dyvars, L_flows, L_sums)
-  
+
   R_stocks::Vector{Symbol} = []
   R_params::Vector{Symbol} = []
   R_dyvars::Vector{Tuple{Symbol,Expr}} = []
@@ -410,8 +409,8 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
   # Allows me to update in R repeatedly.
   R_dict = Dict{Any, Tuple}()
 
-  
-  
+
+
   current_phase = (_, _) -> ()
   for statement in block.args
     @match statement begin
@@ -425,7 +424,7 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
             remove_from_sums!(removed, sf_block, L_block, L_set, name_dict)
             remove_from_dyvars!(removed, sf_block, L_block, L_set, name_dict)
             if name_dict[removed][1] == :F
-              index = name_dict[removed][2] 
+              index = name_dict[removed][2]
               definition = deepcopy(sf_block.flows[index])
               stock1 = definition[1]
               if stock1 != :F_NONE && stock1 ∉ L_set && stock1 ∈ keys(name_dict)
@@ -452,7 +451,7 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
         current_phase = redef -> begin
           @match redef begin
             Expr(:(=), src, tgt) => begin
-              
+
 
               src_type = name_dict[src][1]
               src_index = name_dict[src][2]
@@ -469,7 +468,7 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
 
 
                 push!(modified_dict, src => parse_dyvar(Expr(:(=), src, Expr(:call, equation_operator, intersection_equation_symbols...)))) # wow.
-                
+
 
                 if src ∉ keys(R_dict)
                   push!(R_dict, src => object_definition)
@@ -480,7 +479,7 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
                   push!(L_block.dyvars, original_definition)
 
                 end
-              
+
               elseif src_type == :SV
                 object_definition = parse_sum(Expr(:(=), src, tgt))
                 original_definition = deepcopy(sf_block.sums[src_index])
@@ -518,7 +517,7 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
 
 
 
-      QuoteNode(:dyvar_swaps) => begin 
+      QuoteNode(:dyvar_swaps) => begin
         current_phase = swap -> begin
           @match swap begin
             Expr(:call, :(=>), src, tgt) => begin
@@ -527,8 +526,8 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
           end
         end
       end
-      QuoteNode(:stocks) => begin 
-        current_phase = s -> begin 
+      QuoteNode(:stocks) => begin
+        current_phase = s -> begin
           @match s begin
             val::Symbol => begin # stocks, params
               object_definition = parse_stock(val)
@@ -539,9 +538,9 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
           end
         end
       end
-      
-      QuoteNode(:parameters) => begin 
-        current_phase = p -> begin 
+
+      QuoteNode(:parameters) => begin
+        current_phase = p -> begin
           @match p begin
             val::Symbol => begin # stocks, params
               object_definition = parse_param(val)
@@ -552,9 +551,9 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
           end
         end
       end
-      
+
       QuoteNode(:dynamic_variables) => begin
-        current_phase = v -> begin 
+        current_phase = v -> begin
           @match v begin
             :($tgt = $def) => begin
               object_definition = parse_dyvar(v)
@@ -565,9 +564,9 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
           end
         end
       end
-      
+
       QuoteNode(:flows) => begin
-        current_phase = f -> begin 
+        current_phase = f -> begin
           @match f begin
              Expr(:call, :(=>), S1::Symbol, rest) => begin # flows
               object_definition = parse_flow(Expr(:call, :(=>), S1, rest))
@@ -579,9 +578,9 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
           end
         end
       end
-      
+
       QuoteNode(:sums) => begin
-        current_phase = sv -> begin 
+        current_phase = sv -> begin
           @match sv begin
             Expr(:(=), tgt::Symbol, Expr(:block, def)) => begin
               object_definition = parse_sum(Expr(:(=), tgt, def))
@@ -592,7 +591,7 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
           end
         end
       end
-      
+
       QuoteNode(kw) =>
         error("Unknown block type for rewrite syntax: " * String(kw))
       _ => current_phase(statement)
@@ -606,7 +605,7 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
   for current_dyvar ∈ L_block.dyvars
     recursively_add_dyvars_L!(current_dyvar, sf_block, L_block, L_set, name_dict)
   end
-  
+
   for sum ∈ L_block.sums
     for stock ∈ sum[2]
       if stock ∉ L_set
@@ -641,10 +640,10 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
       end
     end
   end
-        
 
 
-  
+
+
   I_block = deepcopy(L_block)
 
 
@@ -667,8 +666,8 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
 
   end
 
-  
-  
+
+
   for (i, sum) ∈ enumerate(I_block.sums)
     if sum[1] in keys(modified_dict)
       I_block.sums[i] = modified_dict[sum[1]]
@@ -730,7 +729,7 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
   end
 
 
-  
+
 
   for current_dyvar ∈ R_block.dyvars
     recursively_add_dyvars_R!(current_dyvar, sf_block, R_block, R_dict, name_dict)
@@ -762,14 +761,14 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
   sort!(R_block.flows, by = x-> get(name_dict, x[2].args[1], mv_array)[2])
 
 
-  
+
   L_args = stock_and_flow_syntax_to_arguments(L_block)
 
-  
+
   L = StockAndFlowF(L_args.stocks, L_args.params, map(kv -> kv.first => StockFlow.Syntax.get(kv.second), L_args.dyvars), L_args.flows, L_args.sums)
 
   I_args = stock_and_flow_syntax_to_arguments(I_block)
-  
+
 
   I = StockAndFlowF(I_args.stocks, I_args.params, map(kv -> kv.first => StockFlow.Syntax.get(kv.second), I_args.dyvars), I_args.flows, I_args.sums)
 
@@ -778,7 +777,7 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
 
   R = StockAndFlowF(R_args.stocks, R_args.params,  map(kv -> kv.first => StockFlow.Syntax.get(kv.second), R_args.dyvars), R_args.flows, R_args.sums)
 
-  
+
 
 
   # Now we line the positions up with the original stockflow
@@ -788,7 +787,7 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
   reset_positions!(sf, L)
   reset_positions!(sf, I)
   reset_positions!(sf, R)
-  
+
   hom = homomorphism
   hom1 = hom(I,L)
   hom2 = hom(I,R)
@@ -808,7 +807,7 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
   end
 
   return sf_rewritten
-    
+
 end
 
 
@@ -847,10 +846,10 @@ Use :removes to delete objects.
 
   v_CCContacts = fcc * v_prevalencev_INC
   v_CAContacts = fca * v_prevalencev_INA
-  
+
   v_ACContacts = fac * v_prevalencev_INC
   v_AAContacts = faa * v_prevalencev_INA
-  
+
   v_prevalencev_INC_post = v_CCContacts + v_CAContacts
   v_prevalencev_INA_post = v_ACContacts + v_AAContacts
 
@@ -864,7 +863,7 @@ macro rewrite(sf, block)
     sfrewrite($sf, $escaped_block)
   end
 end
-  
+
 
 
 end

--- a/src/syntax/Stratification.jl
+++ b/src/syntax/Stratification.jl
@@ -5,16 +5,16 @@ using ...StockFlow
 using ..Syntax
 using MLStyle
 import Base: get
-using Catlab.CategoricalAlgebra
+using Catlab
 import ..Syntax: infer_links, substitute_symbols, DSLArgument, NothingFunction, invert_vector
 
 
 
 struct SFNames
 
-    sf::AbstractStockAndFlowF 
+    sf::AbstractStockAndFlowF
 
-    snames::Vector{Symbol} 
+    snames::Vector{Symbol}
     svnames::Vector{Symbol}
     vnames::Vector{Symbol}
     fnames::Vector{Symbol}
@@ -114,7 +114,7 @@ function interpret_stratification_standard_notation(mapping_pair::Expr)::Vector{
                 _ => "Unknown format found for match; middle three values formatted incorrectly."
             end
         end
-        _ => error("Unknown line format found in stratification notation.") 
+        _ => error("Unknown line format found in stratification notation.")
     end
 end
 
@@ -141,7 +141,7 @@ function read_stratification_line_and_update_dictionaries!(line::Expr, other_nam
         interpret_stratification_notation_function = interpret_stratification_generalized_notation
 
         # need to do this here, since we know the number of other_mappings at this point, but not in the interpret_stratification_notation
-        @assert length(line.args) == 3 
+        @assert length(line.args) == 3
         @assert typeof(line.args[3]) == Symbol
         @assert line.args[1] == :(=>)
         @assert length(line.args[2].args) == length(other_names)
@@ -150,7 +150,7 @@ function read_stratification_line_and_update_dictionaries!(line::Expr, other_nam
         # In the future, if we have additional flags, may need to check for them as well.
         # These asserts are a bit sloppy
     end
-    
+
     current_symbol_dict::Vector{Vector{DSLArgument}} = interpret_stratification_notation_function(line)
 
     current_mapping_dict::Vector{Dict{Int, Int}} = ((x, y) -> substitute_symbols(x,type_names, y; use_flags=use_flags)).(other_names, current_symbol_dict)
@@ -177,7 +177,7 @@ end
 Iterates over each line in a stratification syntax block and updates the appropriate dictionaries.
 """
 function iterate_over_stratification_lines!(block, other_names::Vector{SFNames}, type_names::SFNames; use_standard_stratification_syntax=true, strict_matches=false, use_flags=true)
-    
+
     current_phase = (_, _) -> ()
     for statement in block.args
         @match statement begin
@@ -186,13 +186,13 @@ function iterate_over_stratification_lines!(block, other_names::Vector{SFNames},
             end
             QuoteNode(:sums) => begin
                 current_phase = sv -> read_stratification_line_and_update_dictionaries!(sv, (getfield.(other_names, :sv))::Vector{Dict{Symbol, Int}}, type_names.sv, (getfield.(other_names, :msv))::Vector{Dict{Int, Int}}; use_standard_stratification_syntax=use_standard_stratification_syntax, strict_matches=strict_matches, use_flags=use_flags)
-            end        
+            end
             QuoteNode(:dynamic_variables) => begin
                 current_phase = v -> read_stratification_line_and_update_dictionaries!(v, (getfield.(other_names, :v))::Vector{Dict{Symbol, Int}}, type_names.v, (getfield.(other_names, :mv))::Vector{Dict{Int, Int}}; use_standard_stratification_syntax=use_standard_stratification_syntax, strict_matches=strict_matches, use_flags=use_flags)
-            end       
+            end
             QuoteNode(:flows) => begin
                 current_phase = f -> read_stratification_line_and_update_dictionaries!(f, (getfield.(other_names, :f))::Vector{Dict{Symbol, Int}}, type_names.f, (getfield.(other_names, :mf))::Vector{Dict{Int, Int}}; use_standard_stratification_syntax=use_standard_stratification_syntax, strict_matches=strict_matches, use_flags=use_flags)
-            end                    
+            end
             QuoteNode(:parameters) => begin
                 current_phase = p -> read_stratification_line_and_update_dictionaries!(p, (getfield.(other_names, :p))::Vector{Dict{Symbol, Int}}, type_names.p, (getfield.(other_names, :mp))::Vector{Dict{Int, Int}}; use_standard_stratification_syntax=use_standard_stratification_syntax, strict_matches=strict_matches, use_flags=use_flags)
             end
@@ -295,20 +295,20 @@ function sfstratify(others::Vector{K}, type::K, block::Expr ; use_standard_strat
 
     # This bit makes debugging when making a stratification easier.  Tells you exactly which ones you forgot to map.
 
-    #unmapped: 
+    #unmapped:
     if !(all(is_all_mapped.(other_names)))
         for i ∈ eachindex(other_names)
             print_unmapped(other_names[i], "STOCKFLOW $i")
         end
         error("There is an unmapped value!")
     end
-    
+
 
     # STEP 5
     # NothingFunction(x...) = nothing;
     no_attribute_type = map(type, Name=NothingFunction, Op=NothingFunction, Position=NothingFunction)
 
-    # STEP 6/7 
+    # STEP 6/7
     # This is where we pull out the magic to infer links.
     #
     #  A <- C -> B
@@ -323,10 +323,10 @@ function sfstratify(others::Vector{K}, type::K, block::Expr ; use_standard_strat
     #  v    v    v
     #  A'<- C'-> B'
     #
-    
+
     generate_all_mappings_function = m -> Dict(infer_links(m.sf, type, get_mappings_infer_links_format(m))..., get_mappings_infer_links_format(m)..., :Op => NothingFunction, :Position => NothingFunction, :Name => NothingFunction)
     all_mappings = generate_all_mappings_function.(other_names)
-   
+
     all_transformations = [ACSetTransformation(sfn.sf, no_attribute_type ; mappings...) for (sfn, mappings) ∈ zip(other_names, all_mappings)]
 
     # STEP 8
@@ -338,7 +338,7 @@ function sfstratify(others::Vector{K}, type::K, block::Expr ; use_standard_strat
     else
         return pullback_model
     end
-    
+
 end
 
 """
@@ -354,30 +354,30 @@ If the type model has a single object in a category, the mapping to it is automa
 @stratify WeightModel l_type ageWeightModel begin
     :stocks
     _ => pop <= _
-    
+
     :flows
     ~Death => f_death <= ~Death
     ~id => f_aging <= ~aging
     ~Becoming => f_fstOrder <= ~id
     _ => f_birth <= f_NB
 
-    
+
     :dynamic_variables
     v_NewBorn => v_birth <= v_NB
     ~Death => v_death <= ~Death
     ~id  => v_aging <= v_agingCA, v_agingAS
     v_BecomingOverWeight, v_BecomingObese => v_fstOrder <= v_idC, v_idA, v_idS
-    
+
     :parameters
     μ => μ <= μ
     δw, δo => δ <= δC, δA, δS
     rw, ro => rFstOrder <= r
     rage => rage <= rageCA, rageAS
-    
+
     :sums
     N => N <= N
-    
-end 
+
+end
 ```
 """
 macro stratify(strata, type, aggregate, block)
@@ -397,26 +397,26 @@ Second last argument must be the type stockflow, last must be the block describi
 @n_stratify WeightModel ageWeightModel l_type begin
     :stocks
     [_, _] => pop
-    
+
     :flows
     [~Death, ~Death] => f_death
-    [~id, ~aging] => f_aging 
+    [~id, ~aging] => f_aging
     [~Becoming, ~id] => f_fstOrder
     [_, f_NB] => f_birth
 
-    
+
     :dynamic_variables
     [v_NewBorn, v_NB] => v_birth
     [~Death, ~Death] => v_death
     [~id, (v_agingCA, v_agingAS)] => v_aging
     [(v_BecomingOverWeight, v_BecomingObese), (v_idC, v_idA, v_idS)] => v_fstOrder
-    
+
     :parameters
     [μ, μ] => μ
     [(δw, δo), (δC, δA, δS)] => δ
     [(rw, ro), r] => rFstOrder
     [rage, (rageCA, rageAS)] => rage
-    
+
     :sums
     [N,N] => N
 end

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -1,5 +1,4 @@
-using Catlab.CategoricalAlgebra
-using Catlab.Graphics.Graphviz: Attributes, Node, Edge, Digraph
+using Catlab.Graphics.Graphviz
 using Base.Iterators: flatten
 using StatsBase
 

--- a/test/CausalLoop.jl
+++ b/test/CausalLoop.jl
@@ -2,11 +2,10 @@ using StockFlow
 using StockFlow.Syntax
 using StockFlow.PremadeModels
 
-using Catlab.CategoricalAlgebra    
-
+using Catlab
 
 @testset "Empty CausalLoop" begin
-    
+
     e = CausalLoop() # Graph with names
     @test (nvert(e) == 0
            && nedges(e) == 0)
@@ -29,7 +28,7 @@ end
 
 
 @testset "sf to causal loop" begin
-    @test (convertToCausalLoop(seir()) 
+    @test (convertToCausalLoop(seir())
            == (@causal_loop begin
             :nodes
             S; E; I; R; f_birth; f_incid; f_deathS; f_inf; f_deathE; f_rec; f_deathI; f_deathR; N; NI; NS; v_prevalence; v_meanInfectiousContactsPerS; v_perSIncidenceRate; μ; β; tlatent; trecovery; δ; c;
@@ -43,15 +42,15 @@ end
              I => NS
              R => N
              R => NS
-             
+
              NI => v_prevalence
              NS => v_prevalence
              N => f_birth
-             
+
              S => f_incid
              E => f_inf
              I => f_rec
-             
+
              S => f_deathS
              E => f_deathE
              I => f_deathI
@@ -60,14 +59,14 @@ end
              f_incid => E
              f_inf => I
              f_rec => R
-             f_incid => S 
+             f_incid => S
              f_deathS => S
              f_inf => E
              f_deathE => E
              f_rec => I
              f_deathI => I
              f_deathR => R
- 
+
              c => v_meanInfectiousContactsPerS
              β => v_perSIncidenceRate
              μ => f_birth
@@ -77,12 +76,12 @@ end
              δ => f_deathE
              δ => f_deathI
              δ => f_deathR
-             
+
              v_prevalence => v_meanInfectiousContactsPerS
              v_meanInfectiousContactsPerS => v_perSIncidenceRate
              v_perSIncidenceRate => f_incid
- 
-         
+
+
             end)
 
           )
@@ -106,7 +105,7 @@ end
                C => -A
            end)
     cl3 = CausalLoopPM([:A,:B,:C,:D], [:A => :B, :B => :C, :C => :A], [POL_POSITIVE, POL_NEGATIVE, POL_NEGATIVE])
-    
+
     @test cl1 == cl2
     @test cl2 == cl3
     @test cl3 == cl1
@@ -118,17 +117,17 @@ end
 
 @testset "Cycles" begin
     clc = (@cl A => +B, A => -B, B => -B, B => -A)
-    
+
     @test cl_cycles(CausalLoopPM()) == Vector{Vector{Int}}()
     @test cl_cycles(clc) == [[1, 4], [2, 4], [3]]
 
     cl = (@cl A => +B, C => -D, D => -C, E => +E)
-    
+
     # Unfortunately, this is pretty non-indicative of what they actually are.
     # Edges are ordered first by pos > neg > zero > nwd > unknown, then by order in which they appear.
     # So, the order of edges here is A => +B == 1, E => +E == 2, C => -D == 3,
     # D => -C == 4
-    @test cl_cycles(cl) == [[3,4], [2]] 
+    @test cl_cycles(cl) == [[3,4], [2]]
 
     @test extract_loops(CausalLoopPM()) == Dict{Vector{Int}, Polarity}()
     @test extract_loops(clc) == Dict([[1,4] => POL_NEGATIVE, [2, 4] => POL_POSITIVE, [3] => POL_NEGATIVE])
@@ -146,7 +145,7 @@ end
     @test !is_circuit((@cl A => +B), [2])
 
     @test walk_polarity(CausalLoopPM(), Vector{Int}()) == POL_POSITIVE
-    @test walk_polarity((@cl A => -B), [1]) == POL_NEGATIVE 
+    @test walk_polarity((@cl A => -B), [1]) == POL_NEGATIVE
     @test walk_polarity((@cl A => -B, B => -A), [1,2]) == POL_POSITIVE
     @test walk_polarity((@cl A => -B, B => -A), [1,2,1]) == POL_NEGATIVE
 end
@@ -180,9 +179,9 @@ end
     @test num_inputs_outputs(@cl A) == Dict([:A => (0, 0)])
     @test num_inputs_outputs(@cl A => +B, B => +C, C => -D) == Dict([:A => (0, 1), :B => (1, 1), :C => (1, 1), :D => (1, 0)])
 
-    @test (num_inputs_outputs_pols(@cl A => +B, A => -C, A => +D, A => -E, A => -B) == 
+    @test (num_inputs_outputs_pols(@cl A => +B, A => -C, A => +D, A => -E, A => -B) ==
     Dict([:A => (0, 2, 0, 3), :B => (1, 0, 1, 0),
-     :C => (0, 0, 1, 0), :D => (1, 0, 0, 0), :E => (0, 0, 1, 0)    
+     :C => (0, 0, 1, 0), :D => (1, 0, 0, 0), :E => (0, 0, 1, 0)
     ]))
 
 end
@@ -220,7 +219,7 @@ end
              [vvi,  vvi,    vve]])
         ))
 
-        @test (all_shortest_paths(@cl A => B, B => C, C => A, D) 
+        @test (all_shortest_paths(@cl A => B, B => C, C => A, D)
         == permutedims(stack(
             [
                 [vve, [[1]], [[1,2]], vvi],
@@ -240,7 +239,7 @@ end
                 [[[3]], vve, [[4]]],
                 [[[5]], [[6]], vve]
             ]
- 
+
 
         )))
 
@@ -261,14 +260,14 @@ end
 
 
     @testset "Betweenness" begin
-        
+
         @test betweenness(@cl) == Vector{Float64}()
         @test betweenness(@cl A => B) == [0.0, 0.0]
         @test betweenness(@cl A => B, B => C) == [0.0, 1.0, 0.0]
 
 
         @test betweenness(@cl A => B, A => B, B => C, B => C) == [0.0, 1.0, 0.0]
-        
+
         # Shortest paths of len > 2:
         # A => B => C
         # A => B => C => D
@@ -322,9 +321,7 @@ end
     (:birth=>:v_birth,:inf=>:v_inf,:rec=>:v_rec,:deathS=>:v_deathS),
     (:N=>(:v_birth,:v_inf)))) == (
         @cl S, birth, inf, rec, deathS, N, S => N, N => birth, N => inf, S => inf, S => deathS, birth => S, inf => S, deathS => S
-    )) 
+    ))
 
 
 end
-
-

--- a/test/syntax/Composition.jl
+++ b/test/syntax/Composition.jl
@@ -2,7 +2,7 @@ using StockFlow
 using StockFlow.Syntax
 using StockFlow.Syntax.Composition
 import StockFlow.Syntax.Composition: interpret_composition_notation
-using Catlab.CategoricalAlgebra
+using Catlab
 
 function ≅(x,y)
   !isnothing(isomorphism(x,y))
@@ -12,10 +12,10 @@ end
     empty_sf = StockAndFlowF()
     A = @stock_and_flow begin; :stocks; A; end;
     AA = @stock_and_flow begin; :stocks; A; A; end;
-    
+
     B = @stock_and_flow begin; :stocks; B; end;
-    AB = @stock_and_flow begin :stocks; A; B; end; 
-    BA = @stock_and_flow begin :stocks; B; A; end; 
+    AB = @stock_and_flow begin :stocks; A; B; end;
+    BA = @stock_and_flow begin :stocks; B; A; end;
 
     @test (@compose empty_sf begin
         (sf,)
@@ -84,7 +84,7 @@ end
             :sums
             N = [A, B, C]
         end))
-        
+
 
 
 end
@@ -126,7 +126,7 @@ end
 
 @testset "Causal Loop composition" begin
     CL1 = @cl B => +A, B => +C, C => +A, G;
-    CL2 = @cl B => +A, A => +D, D => -E;       
+    CL2 = @cl B => +A, A => +D, D => -E;
     CL3 = @cl B => +C, C => -F, F => +E, E => + B, G;
 
     BigCL = @causal_loop begin
@@ -167,7 +167,7 @@ end
     ABC = (@cl A => B, B => C)
     BCD = (@cl B => C, C => D)
     ABCD = (@cl A => B, B => C, C => D)
-    
+
     @test (@compose ABC BCD begin
         (bc, cd)
         (bc, cd) ^ B => C
@@ -177,7 +177,7 @@ end
         (abc1, abc2)
         (abc1, abc2) ^ A => B, B => C
     end) == ABC
-    
-      
+
+
 
 end

--- a/test/syntax/Rewrite.jl
+++ b/test/syntax/Rewrite.jl
@@ -5,7 +5,7 @@ using StockFlow.Syntax
 using StockFlow.Syntax.Rewrite
 
 using StockFlow.Syntax.Stratification
-using Catlab.CategoricalAlgebra
+using Catlab
 using AlgebraicRewriting
 
 
@@ -21,7 +21,7 @@ using AlgebraicRewriting
 
   @test (@rewrite empty begin
     :stocks
-    A    
+    A
     end) == A
 
   @test (@rewrite A begin
@@ -58,7 +58,7 @@ using AlgebraicRewriting
     :parameters
     p
   end) == Ap
-    
+
 
 end
 
@@ -280,7 +280,7 @@ end
   end) begin
     :removes
     A
-  end) == (@stock_and_flow begin 
+  end) == (@stock_and_flow begin
     :sums
     N = []
   end)
@@ -290,44 +290,44 @@ end
 
 
 @testset "Substantial examples" begin
-  
+
   age2 = @stock_and_flow begin
     :stocks
     Child
     Adult
-    
+
     :parameters
     c_C
     β
     r
     rAge
     c_A
-    
+
     :dynamic_variables
     v_INC = Child / NC
     v_cINC = c_C * v_INC
     v_cβINC = β * v_cINC
-    
+
     v_infC = Child * v_cβINC
     v_fstC = Child * r
     v_agingC = Child * rAge
-    
-    
+
+
     v_INA = Adult / NA
     v_cINA = c_A * v_INA
     v_cβINA = β * v_cINA
-    
+
     v_infA = Adult * v_cβINA
     v_fstA = Adult * r
-    
+
     :flows
     Child => f_infC(v_infC) => Child
     Child => f_frsC(v_fstC) => Child
     Child => f_aging(v_agingC) => Adult
     Adult => f_infA(v_infA) => Adult
     Adult => f_frsA(v_fstA) => Adult
-    
-    
+
+
     :sums
     NC = [Child]
     NA = [Adult]
@@ -338,13 +338,13 @@ end
     S
     I
     R
-    
+
     :parameters
     c
     β
     rRec
     rAge
-    
+
     :dynamic_variables
     v_prevalence = I / N
     v_meanInfectiousContactsPerS = c * v_prevalence
@@ -354,30 +354,30 @@ end
     v_idS = S * rAge
     v_idI = I * rAge
     v_idR = R * rAge
-    
+
     :flows
     S => f_idS(v_idS) => S
     S => f_inf(v_newInfections) => I
     I => f_idI(v_idI) => I
     I => f_rec(v_newRecovery) => R
     R => f_idR(v_idR) => R
-    
+
     :sums
     N = [S, I, R]
-    
-    
+
+
   end
 
   s_type = @stock_and_flow begin
     :stocks
     pop
-    
+
     :parameters
     c
     β
     rFstOrder
     rAge
-    
+
     :dynamic_variables
     v_prevalence = pop / N
     v_meanInfectiousContactsPerS = c * v_prevalence
@@ -385,17 +385,17 @@ end
     v_inf = pop * v_perSIncidenceRate
     v_fstOrder = pop * rFstOrder
     v_aging = pop * rAge
-    
+
     :flows
     pop => f_inf(v_inf) => pop
     pop => f_fstOrder(v_fstOrder) => pop
     pop => f_aging(v_aging) => pop
 
-    
+
     :sums
     N = [pop]
-    
-    
+
+
   end
 
 
@@ -403,7 +403,7 @@ end
 
 
   aged_sir = @stratify sir s_type age2 begin
-    
+
     :parameters
     c => c <= c_C, c_A
     β => β <= β
@@ -412,7 +412,7 @@ end
 
     :dynamic_variables
     v_prevalence => v_prevalence <= ~v_IN
-    v_meanInfectiousContactsPerS => v_meanInfectiousContactsPerS <= ~v_cIN 
+    v_meanInfectiousContactsPerS => v_meanInfectiousContactsPerS <= ~v_cIN
     v_perSIncidenceRate => v_perSIncidenceRate <= ~v_cβIN
     v_newInfections => v_inf <= ~v_inf
     v_newRecovery => v_fstOrder <= ~v_fst
@@ -443,10 +443,10 @@ end
 
     v_CCContacts = fcc * v_prevalencev_INC
     v_CAContacts = fca * v_prevalencev_INA
-    
+
     v_ACContacts = fac * v_prevalencev_INC
     v_AAContacts = faa * v_prevalencev_INA
-    
+
     v_prevalencev_INC_post = v_CCContacts + v_CAContacts
     v_prevalencev_INA_post = v_ACContacts + v_AAContacts
 
@@ -459,23 +459,23 @@ end
     IChild
     SAdult
     IAdult
-    
+
     :parameters
     cc_C
     cc_A
-    
+
     :dynamic_variables
     v_prevalencev_INC = IChild / NNC
     v_prevalencev_INA = IAdult / NNA
     v_meanInfectiousContactsPerSv_cINC = cc_C * v_prevalencev_INC
     v_meanInfectiousContactsPerSv_cINA = cc_A * v_prevalencev_INA
-    
-    
+
+
     :sums
     NNC = [SChild, IChild]
     NNA = [SAdult, IAdult]
-    
-    
+
+
   end
 
 
@@ -486,22 +486,22 @@ end
       IChild
       SAdult
       IAdult
-      
+
       :parameters
       cc_C
       cc_A
-      
+
       :dynamic_variables
       v_prevalencev_INC = IChild / NNC
       v_prevalencev_INA = IAdult / NNA
       v_meanInfectiousContactsPerSv_cINC = *(cc_C)
       v_meanInfectiousContactsPerSv_cINA = *(cc_A)
-      
+
       :sums
       NNC = [SChild, IChild]
       NNA = [SAdult, IAdult]
-      
-      
+
+
   end
 
 
@@ -511,7 +511,7 @@ end
       IChild
       SAdult
       IAdult
-      
+
       :parameters
       fcc
       fca
@@ -519,26 +519,26 @@ end
       faa
       cc_C
       cc_A
-      
+
       :dynamic_variables
       v_prevalencev_INC = IChild / NNC
       v_prevalencev_INA = IAdult / NNA
       v_CCContacts = fcc * v_prevalencev_INC
       v_CAContacts = fca * v_prevalencev_INA
-      
+
       v_ACContacts = fac * v_prevalencev_INC
       v_AAContacts = faa * v_prevalencev_INA
-      
+
       v_prevalencev_INC_post = v_CCContacts + v_CAContacts
       v_prevalencev_INA_post = v_ACContacts + v_AAContacts
       v_meanInfectiousContactsPerSv_cINC = cc_C * v_prevalencev_INC_post
       v_meanInfectiousContactsPerSv_cINA = cc_A * v_prevalencev_INA_post
-      
+
       :sums
       NNC = [SChild, IChild]
       NNA = [SAdult, IAdult]
-      
-      
+
+
   end
 
 
@@ -548,4 +548,3 @@ end
 
 
 end
-

--- a/test/syntax/Stratification.jl
+++ b/test/syntax/Stratification.jl
@@ -3,9 +3,7 @@ using StockFlow.Syntax.Stratification
 using StockFlow.Syntax.Stratification: interpret_stratification_standard_notation
 using StockFlow.Syntax: NothingFunction, DSLArgument, unwrap_expression, substitute_symbols
 
-using Catlab.WiringDiagrams
-using Catlab.ACSets
-using Catlab.CategoricalAlgebra
+using Catlab
 
 
 
@@ -13,41 +11,41 @@ using Catlab.CategoricalAlgebra
 @testset "Pullback computed in standard way is equal to DSL pullbacks" begin
 
 
-    l_type = @stock_and_flow begin 
+    l_type = @stock_and_flow begin
         :stocks
         pop
-        
+
         :parameters
         μ
         δ
         rFstOrder
         rage
-        
+
         :dynamic_variables
         v_aging = pop * rage
         v_fstOrder = pop * rFstOrder
         v_birth = N * μ
         v_death = pop * δ
-        
+
         :flows
         pop => f_aging(v_aging) => pop
         pop => f_fstOrder(v_fstOrder) => pop
         CLOUD => f_birth(v_birth) => pop
         pop => f_death(v_death) => CLOUD
-        
+
         :sums
         N = [pop]
-        
+
     end;
     l_type_noatts = map(l_type, Name=NothingFunction, Op=NothingFunction, Position=NothingFunction);
-    
-    
+
+
     WeightModel = @stock_and_flow begin
         :stocks
         NormalWeight
         OverWeight
         Obese
-        
+
         :parameters
         μ
         δw
@@ -55,7 +53,7 @@ using Catlab.CategoricalAlgebra
         ro
         δo
         rage
-        
+
         :dynamic_variables
         v_NewBorn = N * μ
         v_DeathNormalWeight = NormalWeight * δw
@@ -66,31 +64,31 @@ using Catlab.CategoricalAlgebra
         v_idNW = NormalWeight * rage
         v_idOW = OverWeight * rage
         v_idOb = Obese * rage
-        
+
         :flows
         CLOUD => f_NewBorn(v_NewBorn) => NormalWeight
         NormalWeight => f_DeathNormalWeight(v_DeathNormalWeight) => CLOUD
         NormalWeight => f_BecomingOverWeight(v_BecomingOverWeight) => OverWeight
         OverWeight => f_DeathOverWeight(v_DeathOverWeight) => CLOUD
-        
+
         OverWeight => f_BecomingObese(v_BecomingObese) => Obese
         Obese => f_DeathObese(v_DeathObese) => CLOUD
         NormalWeight => f_idNW(v_idNW) => NormalWeight
         OverWeight => f_idOW(v_idOW) => OverWeight
         Obese => f_idOb(v_idOb) => Obese
-        
+
         :sums
         N = [NormalWeight, OverWeight, Obese]
-        
+
     end;
-    
-    
+
+
     ageWeightModel = @stock_and_flow begin
         :stocks
         Child
         Adult
         Senior
-        
+
         :parameters
         μ
         δC
@@ -99,7 +97,7 @@ using Catlab.CategoricalAlgebra
         rageCA
         rageAS
         r
-        
+
         :dynamic_variables
         v_NB = N * μ
         v_DeathC = Child * δC
@@ -110,7 +108,7 @@ using Catlab.CategoricalAlgebra
         v_agingAS = Adult * rageAS
         v_DeathS = Senior * δS
         v_idS = Senior * r
-        
+
         :flows
         CLOUD => f_NB(v_NB) => Child
         Child => f_idC(v_idC) => Child
@@ -121,12 +119,12 @@ using Catlab.CategoricalAlgebra
         Adult => f_agingAS(v_agingAS) => Senior
         Senior => f_idS(v_idS) => Senior
         Senior => f_DeathS(v_DeathS) => CLOUD
-        
+
         :sums
         N = [Child, Adult, Senior]
-            
+
     end;
-    
+
     begin
         s, = parts(l_type, :S)
         N, = parts(l_type, :SV)
@@ -140,13 +138,13 @@ using Catlab.CategoricalAlgebra
         p_μ, p_δ, p_rfstOrder, p_rage = parts(l_type, :P)
         lpv_aging2, lpv_fstorder2, lpv_birth2, lpv_death2 = parts(l_type, :LPV)
     end;
-    
+
     typed_WeightModel=ACSetTransformation(WeightModel, l_type_noatts,
       S = [s,s,s],
       SV = [N],
-      LS = [lsn,lsn,lsn],   
-      F = [f_birth, f_death, f_fstorder, f_death, f_fstorder, f_death, f_aging, f_aging, f_aging],    
-      I = [i_birth, i_aging, i_fstorder, i_aging, i_fstorder, i_aging], 
+      LS = [lsn,lsn,lsn],
+      F = [f_birth, f_death, f_fstorder, f_death, f_fstorder, f_death, f_aging, f_aging, f_aging],
+      I = [i_birth, i_aging, i_fstorder, i_aging, i_fstorder, i_aging],
       O = [o_death, o_fstorder, o_aging, o_death, o_fstorder, o_aging, o_death, o_aging],
       V = [v_birth, v_death, v_fstorder, v_death, v_fstorder, v_death, v_aging, v_aging, v_aging],
       LV = [lv_death1, lv_fstorder1, lv_death1, lv_fstorder1, lv_death1, lv_aging1, lv_aging1, lv_aging1],
@@ -156,15 +154,15 @@ using Catlab.CategoricalAlgebra
       Name=NothingFunction, Op=NothingFunction, Position=NothingFunction
     );
     @assert is_natural(typed_WeightModel);
-    
-    
-    
+
+
+
     typed_ageWeightModel=ACSetTransformation(ageWeightModel, l_type_noatts,
       S = [s,s,s],
       SV = [N],
-      LS = [lsn,lsn,lsn],   
-      F = [f_birth, f_fstorder, f_death, f_aging, f_fstorder, f_death, f_aging, f_fstorder, f_death],    
-      I = [i_birth, i_fstorder, i_aging, i_fstorder, i_aging, i_fstorder], 
+      LS = [lsn,lsn,lsn],
+      F = [f_birth, f_fstorder, f_death, f_aging, f_fstorder, f_death, f_aging, f_fstorder, f_death],
+      I = [i_birth, i_fstorder, i_aging, i_fstorder, i_aging, i_fstorder],
       O = [o_fstorder, o_death, o_aging, o_fstorder, o_death, o_aging, o_fstorder, o_death],
       V = [v_birth, v_death, v_fstorder, v_aging, v_death, v_fstorder, v_aging, v_death, v_fstorder],
       LV = [lv_death1, lv_fstorder1, lv_aging1, lv_death1, lv_fstorder1, lv_aging1, lv_death1, lv_fstorder1],
@@ -174,63 +172,63 @@ using Catlab.CategoricalAlgebra
       Name =NothingFunction, Op=NothingFunction, Position=NothingFunction
     );
     @assert is_natural(typed_ageWeightModel);
-    
+
     aged_weight = pullback(typed_WeightModel, typed_ageWeightModel) |> apex |> rebuildStratifiedModelByFlattenSymbols;
-    
+
     # #########################################
-    
-    age_weight_2 = @stratify WeightModel l_type ageWeightModel begin 
+
+    age_weight_2 = @stratify WeightModel l_type ageWeightModel begin
         :stocks
         NormalWeight, OverWeight, Obese => pop <= Child, Adult, Senior
-    
+
         :flows
         f_NewBorn => f_birth <= f_NB
         f_DeathNormalWeight, f_DeathOverWeight, f_DeathObese => f_death <= f_DeathC, f_DeathA, f_DeathS
         f_idNW, f_idOW, f_idOb => f_aging <= f_agingCA, f_agingAS
         f_BecomingOverWeight, f_BecomingObese => f_fstOrder <= f_idC, f_idA, f_idS
-    
+
         :dynamic_variables
         v_NewBorn => v_birth <= v_NB
         v_DeathNormalWeight, v_DeathOverWeight, v_DeathObese => v_death <= v_DeathC, v_DeathA, v_DeathS
         v_idNW, v_idOW, v_idOb  => v_aging <= v_agingCA, v_agingAS
         v_BecomingOverWeight, v_BecomingObese => v_fstOrder <= v_idC, v_idA, v_idS
-    
+
         :parameters
         μ => μ <= μ
         δw, δo => δ <= δC, δA, δS
         rw, ro => rFstOrder <= r
         rage => rage <= rageCA, rageAS
-    
+
         :sums
         N => N <= N
-        
+
     end
     #########################################
-    
+
     age_weight_3 =  @stratify WeightModel l_type ageWeightModel begin
-    
+
         :flows
         f_NewBorn => f_birth <= f_NB
         ~Death => f_death <= ~Death
         ~id => f_aging <= ~aging
         ~Becoming => f_fstOrder <= ~id
-    
+
         :dynamic_variables
         v_NewBorn => v_birth <= v_NB
         ~Death => v_death <= ~Death
         ~id  => v_aging <= ~aging
         ~Becoming => v_fstOrder <= ~id
-    
+
         :parameters
         μ => μ <= μ
         ~δ => δ <= ~δ
         rage => rage <= rageCA, rageAS
         _ => rFstOrder <= _
-    
-    end 
-    
+
+    end
+
     age_weight_4 =  @stratify WeightModel l_type ageWeightModel begin
-    
+
         :flows
         ~NO_MATCHES => f_birth <= ~NO_MATCHES
         f_NewBorn => f_birth <= f_NB
@@ -239,44 +237,44 @@ using Catlab.CategoricalAlgebra
         ~Becoming => f_fstOrder <= ~id
         ~Becoming => f_aging <= ~id # Everything already matched; ignored
         _ => f_aging <= _ # also ignored
-    
+
         :dynamic_variables
         v_NewBorn => v_birth <= v_NB
         ~Death => v_death <= ~Death
         ~id  => v_aging <= ~aging
         _ => v_fstOrder <= _
-    
+
         :parameters
         μ => μ <= μ
         ~δ => δ <= ~δ
         rage => rage <= rageCA, rageAS
         _ => rFstOrder <= _
-    
+
     end
 
     age_weight_5 = @n_stratify WeightModel ageWeightModel l_type begin
         :stocks
         [_, _] => pop
-        
+
         :flows
         [~Death, ~Death] => f_death
-        [~id, ~aging] => f_aging 
+        [~id, ~aging] => f_aging
         [~Becoming, ~id] => f_fstOrder
         [_, f_NB] => f_birth
-    
-        
+
+
         :dynamic_variables
         [v_NewBorn, v_NB] => v_birth
         [~Death, ~Death] => v_death
         [~id, (v_agingCA, v_agingAS)] => v_aging
         [(v_BecomingOverWeight, v_BecomingObese), (v_idC, v_idA, v_idS)] => v_fstOrder
-        
+
         :parameters
         [μ, μ] => μ
         [(δw, δo), (δC, δA, δS)] => δ
         [(rw, ro), r] => rFstOrder
         [rage, (rageCA, rageAS)] => rage
-        
+
         :sums
         [N,N] => N
     end
@@ -285,17 +283,17 @@ using Catlab.CategoricalAlgebra
 
         :flows
         [~Death, ~Death] => f_death
-        [~id, ~aging] => f_aging 
+        [~id, ~aging] => f_aging
         [~Becoming, ~id] => f_fstOrder
         [_, f_NB] => f_birth
-    
-        
+
+
         :dynamic_variables
         [v_NewBorn, v_NB] => v_birth
         [~Death, ~Death] => v_death
         [~id, (v_agingCA, v_agingAS)] => v_aging
         [(v_BecomingOverWeight, v_BecomingObese), (v_idC, v_idA, v_idS)] => v_fstOrder
-        
+
         :parameters
         [μ, μ] => μ
         [(δw, δo), (δC, δA, δS)] => δ
@@ -319,7 +317,7 @@ end
 
 
     @test interpret_stratification_standard_notation(:(A => B <= C)) == [[DSLArgument(:A, :B, Set{Symbol}())], [DSLArgument(:C, :B, Set{Symbol}())]]
-    
+
     @test interpret_stratification_standard_notation(:(A1, A2 => B <= C)) == [
         [DSLArgument(:A1, :B, Set{Symbol}()), DSLArgument(:A2, :B, Set{Symbol}())],
         [DSLArgument(:C, :B, Set{Symbol}())]
@@ -363,7 +361,7 @@ end
     t1 = Dict(:B => 2)
     m1₁ = [DSLArgument(:A, :B, Set{Symbol}())]
     m1₂ = [DSLArgument(:A, :B, Set{Symbol}([:~]))]
- 
+
     @test substitute_symbols(s1, t1, m1₁) == Dict(1 => 2) # A=>B -> 1=>2
     @test substitute_symbols(s1, t1, m1₂) == Dict(1 => 2) # A=>B -> 1=>2
     @test substitute_symbols(s1, t1, m1₂, use_flags=false) == Dict(1 => 2) # A=>B -> 1=>2
@@ -427,7 +425,7 @@ end
     end))
 
     # doesn't show up anywhere, so doesn't affect anything.  Could also set it to something untypable in the DSL, like Symbol("")
-    @test (sfstratify([A_, B_], X_, strat_AXB, temp_strat_default=:ABABABABA) 
+    @test (sfstratify([A_, B_], X_, strat_AXB, temp_strat_default=:ABABABABA)
     == (@stock_and_flow begin
         :stocks
         AB
@@ -458,55 +456,55 @@ end
 @testset "n_stratify works as expected" begin
 
 
-    l_type = @stock_and_flow begin 
+    l_type = @stock_and_flow begin
         :stocks
         pop
-        
+
         :parameters
         μ
         δ
         rFstOrder
         rage
-        
+
         :dynamic_variables
         v_aging = pop * rage
         v_fstOrder = pop * rFstOrder
         v_birth = N * μ
         v_death = pop * δ
-        
+
         :flows
         pop => f_aging(v_aging) => pop
         pop => f_fstOrder(v_fstOrder) => pop
         CLOUD => f_birth(v_birth) => pop
         pop => f_death(v_death) => CLOUD
-        
+
         :sums
         N = [pop]
-        
+
     end
 
     chain_ltype = @stock_and_flow begin
         :stocks
         poppoppop
-    
+
         :parameters
         μμμ
         δδδ
         rFstOrderrFstOrderrFstOrder
         rageragerage
-    
+
         :dynamic_variables
         v_agingv_agingv_aging = poppoppop * rageragerage
         v_fstOrderv_fstOrderv_fstOrder = poppoppop * rFstOrderrFstOrderrFstOrder
         v_birthv_birthv_birth = NNN * μμμ
         v_deathv_deathv_death = poppoppop * δδδ
-    
+
         :flows
         poppoppop => f_agingf_agingf_aging(v_agingv_agingv_aging) => poppoppop
         poppoppop => f_fstOrderf_fstOrderf_fstOrder(v_fstOrderv_fstOrderv_fstOrder) => poppoppop
         CLOUD => f_birthf_birthf_birth(v_birthv_birthv_birth) => poppoppop
         poppoppop => f_deathf_deathf_death(v_deathv_deathv_death) => CLOUD
-    
+
         :sums
         NNN = [poppoppop]
     end
@@ -515,30 +513,30 @@ end
 
         :stocks
         [pop, ~pop, _] => pop
-        
+
         :parameters
         [μ, μ, μ] => μ
         [δ, δ, δ] => δ
         [rFstOrder, rFstOrder, rFstOrder] => rFstOrder
         [rage, rage, rage] => rage
-        
+
         :dynamic_variables
         [v_aging, v_aging, v_aging] => v_aging
         [v_fstOrder, v_fstOrder, v_fstOrder] => v_fstOrder
         [v_birth, v_birth, v_birth] => v_birth
         [v_death, v_death, v_death] => v_death
-        
+
         :flows
         [f_aging, f_aging, f_aging] => f_aging
         [f_fstOrder, f_fstOrder, f_fstOrder] => f_fstOrder
         [f_birth, f_birth, f_birth] => f_birth
         [f_death, f_death, f_death] => f_death
-        
+
         :sums
         [N, N, N] => N
     end
 
-    
+
     @test chain_ltype == chain_ltype_nstratify
 
 
@@ -546,34 +544,30 @@ end
 
         :stocks
         [pop] => pop
-        
+
         :parameters
         [μ] => μ
         [δ] => δ
         [rFstOrder] => rFstOrder
         [rage] => rage
-        
+
         :dynamic_variables
         [v_aging] => v_aging
         [v_fstOrder] => v_fstOrder
         [v_birth] => v_birth
         [v_death] => v_death
-        
+
         :flows
         [f_aging] => f_aging
         [f_fstOrder] => f_fstOrder
         [f_birth] => f_birth
         [f_death] => f_death
-        
+
         :sums
         [N] => N
     end
 
     @test ltype_nstratify == l_type
-        
-    
+
+
 end
-
-
-
-


### PR DESCRIPTION
StockFlow.jl does not seem to currently compile as it exists in `main`.

This makes a couple changes to allow StockFlow.jl to compile again, including:

- Changing several Catlab imports to just use the primary `Catlab` module, which I am assuming is their public API module, to avoid running into module naming flux which I encountered trying to update to Catlab 0.17
- Fixing usage of a change data type `UntypedUnnamedRelationDiagram` to `UntypedRelationDiagram`